### PR TITLE
Use HalfInteger type internally

### DIFF
--- a/src/AtomicLevels.jl
+++ b/src/AtomicLevels.jl
@@ -8,6 +8,7 @@ using WignerSymbols
 
 include("common.jl")
 include("parity.jl")
+include("halfinteger.jl")
 include("orbitals.jl")
 include("configurations.jl")
 include("excited_configurations.jl")

--- a/src/allchoices.jl
+++ b/src/allchoices.jl
@@ -6,6 +6,7 @@ function allchoices(choices::Vector{V}) where {T,V<:AbstractVector{T}}
     allchoices(choices, length.(choices))
 end
 Base.length(ac::allchoices) = prod(ac.dims)
+Base.eltype(ac::allchoices{T}) where T = Vector{T}
 
 function Base.iterate(ac::allchoices{T,V}, (el,i)=(first.(ac.choices),ones(Int,length(ac.dims)))) where {T,V}
     i == 0 && return nothing

--- a/src/csfs.jl
+++ b/src/csfs.jl
@@ -1,4 +1,4 @@
-struct CSF{O<:AbstractOrbital, T<:Union{Term{Rational{Int}},Rational{Int}}}
+struct CSF{O<:AbstractOrbital, T<:Union{Term,HalfInteger}}
     config::Configuration{<:O}
     subshell_terms::Vector{T}
     terms::Vector{T}
@@ -9,12 +9,13 @@ struct CSF{O<:AbstractOrbital, T<:Union{Term{Rational{Int}},Rational{Int}}}
     end
 
     function CSF(config::Configuration{<:RelativisticOrbital},
-                 subshell_terms::Vector{R}, terms::Vector{R}) where {R<:Rational{Int}}
+                 subshell_terms::Vector{R}, terms::Vector{R}) where {R<:Real}
         length(subshell_terms) == length(peel(config)) ||
             throw(ArgumentError("Need to provide $(length(peel(config))) subshell terms for $(config)"))
         length(terms) == length(peel(config)) ||
             throw(ArgumentError("Need to provide $(length(peel(config))) terms for $(config)"))
-        new{RelativisticOrbital,R}(config, subshell_terms, terms)
+        new{RelativisticOrbital,HalfInteger}(config, convert.(HalfInteger, subshell_terms),
+            convert.(HalfInteger, terms))
     end
 end
 
@@ -33,7 +34,7 @@ function csfs(config::Configuration{<:RelativisticOrbital})
     end |> c -> vcat(c...) |> sort
 end
 
-function Base.show(io::IO, csf::CSF{<:RelativisticOrbital,Rational{Int}})
+function Base.show(io::IO, csf::CSF{<:RelativisticOrbital,HalfInteger})
     c = core(csf.config)
     p = peel(csf.config)
     nc = length(c)
@@ -50,7 +51,7 @@ function Base.show(io::IO, csf::CSF{<:RelativisticOrbital,Rational{Int}})
     print(io, iseven(parity(csf.config)) ? "+" : "-")
 end
 
-function Base.show(io::IO, ::MIME"text/plain", csf::CSF{<:RelativisticOrbital,Rational{Int}})
+function Base.show(io::IO, ::MIME"text/plain", csf::CSF{<:RelativisticOrbital,HalfInteger})
     c = core(csf.config)
     nc = length(c)
     cw = length(string(c))

--- a/src/halfinteger.jl
+++ b/src/halfinteger.jl
@@ -1,0 +1,132 @@
+# Largely borrowed from WignerSymbols.jl (https://github.com/Jutho/WignerSymbols.jl)
+# Copyright (c) 2017: Jutho Haegeman; MIT "Expat" License
+"""
+    struct HalfInteger <: Real
+
+Represents half-integer values.
+"""
+struct HalfInteger <: Real
+    num::Int
+    function HalfInteger(; twoX = nothing)
+        return new(twoX)
+    end
+end
+HalfInteger(x::Real) = convert(HalfInteger, x)
+
+Base.:+(a::HalfInteger, b::HalfInteger) = HalfInteger(twoX = a.num+b.num)
+Base.:-(a::HalfInteger, b::HalfInteger) = HalfInteger(twoX = a.num-b.num)
+Base.:-(a::HalfInteger) = HalfInteger(twoX = -a.num)
+Base.:*(a::Integer, b::HalfInteger) = HalfInteger(twoX = a * b.num)
+Base.:*(a::HalfInteger, b::Integer) = b * a
+Base.:<=(a::HalfInteger, b::HalfInteger) = a.num <= b.num
+Base.:<(a::HalfInteger, b::HalfInteger) = a.num < b.num
+Base.one(::Type{HalfInteger}) = HalfInteger(twoX = 2)
+Base.zero(::Type{HalfInteger}) = HalfInteger(twoX = 0)
+
+Base.promote_rule(::Type{HalfInteger}, ::Type{<:Integer}) = HalfInteger
+Base.promote_rule(::Type{HalfInteger}, T::Type{<:Rational}) = T
+Base.promote_rule(::Type{HalfInteger}, T::Type{<:Real}) = T
+
+Base.convert(::Type{HalfInteger}, n::Integer) = HalfInteger(twoX = 2*n)
+function Base.convert(::Type{HalfInteger}, r::Rational)
+    if r.den == 1
+        return HalfInteger(twoX = 2*r.num)
+    elseif r.den == 2
+        return HalfInteger(twoX = r.num)
+    else
+        throw(InexactError(:HalfInteger, HalfInteger, r))
+    end
+end
+function Base.convert(::Type{HalfInteger}, r::Real)
+    num = 2*r
+    if isinteger(num)
+        return HalfInteger(twoX = convert(Int, num))
+    else
+        throw(InexactError(:HalfInteger, HalfInteger, r))
+    end
+end
+Base.convert(T::Type{<:Integer}, s::HalfInteger) =
+    iseven(s.num) ? convert(T, s.num>>1) : throw(InexactError(Symbol(T), T, s))
+Base.convert(T::Type{<:Rational}, s::HalfInteger) = convert(T, s.num//2)
+Base.convert(T::Type{<:Real}, s::HalfInteger) = convert(T, s.num/2)
+Base.convert(::Type{HalfInteger}, s::HalfInteger) = s
+
+Base.isinteger(a::HalfInteger) = iseven(a.num)
+ishalfinteger(a::HalfInteger) = true
+ishalfinteger(a::Integer) = true
+ishalfinteger(a::Rational) = (a.den == 1) || (a.den == 2)
+ishalfinteger(a::Real) = isinteger(2*a)
+
+converthalfinteger(a::Number) = convert(HalfInteger, a)
+
+Base.numerator(a::HalfInteger) = iseven(a.num) ? div(a.num, 2) : a.num
+Base.denominator(a::HalfInteger) = iseven(a.num) ? 1 : 2
+
+"""
+    parse(HalfInteger, s)
+
+Parses the string `s` into the corresponding `HalfInteger`-value. String can either be a
+number or a fraction of the form `<x>/2`.
+"""
+function Base.parse(::Type{HalfInteger}, s::AbstractString)
+    if in('/', s)
+        J_numerator, J_denominator = split(s, '/'; limit=2)
+        parse(Int, J_denominator) == 2 ||
+            throw(ArgumentError("Denominator not 2 in HalfInteger string '$s'."))
+        HalfInteger(parse(Int, J_numerator) // 2)
+    elseif !isempty(strip(s))
+        HalfInteger(parse(Int, s))
+    else
+        throw(ArgumentError("input string is empty or only contains whitespace"))
+    end
+end
+
+macro hi_str(s)
+    parse(HalfInteger, s)
+end
+
+Base.show(io::IO, am::HalfInteger) =
+    print(io, iseven(am.num) ? "$(div(am.num, 2))" : "$(am.num)/2")
+
+function Base.hash(a::HalfInteger, h::UInt)
+    iseven(a.num) && return hash(a.num>>1, h)
+    num, den = a.num, 2
+    den = 1
+    pow = -1
+    if abs(num) < 9007199254740992
+        return hash(ldexp(Float64(num),pow), h)
+    end
+    h = Base.hash_integer(den, h)
+    h = Base.hash_integer(pow, h)
+    h = Base.hash_integer(num, h)
+    return h
+end
+
+
+struct HalfIntegerRange <: AbstractVector{HalfInteger}
+    start :: HalfInteger
+    stop :: HalfInteger
+
+    function HalfIntegerRange(start::HalfInteger, stop::HalfInteger)
+        (start <= stop) ||
+            throw(ArgumentError("Second argument must be greater or equal to the first."))
+        isinteger(stop - start) ||
+            throw(ArgumentError("Two arguments must have integer difference."))
+        return new(start, stop)
+    end
+end
+Base.iterate(it::HalfIntegerRange) = (it.start, it.start + 1)
+Base.iterate(it::HalfIntegerRange, s) = (s <= it.stop) ? (s, s+1) : nothing
+Base.length(it::HalfIntegerRange) = convert(Int, it.stop - it.start) + 1
+Base.size(it::HalfIntegerRange) = (length(it),)
+function Base.getindex(it::HalfIntegerRange, i::Integer)
+    1 <= i <= length(it) || throw(BoundsError(it, i))
+    it.start + i - 1
+end
+Base.IteratorEltype(::HalfIntegerRange) = Base.HasEltype()
+Base.eltype(::HalfIntegerRange) = HalfInteger
+Base.IteratorSize(::HalfIntegerRange) = Base.HasLength()
+
+Base.:(:)(i::HalfInteger, j::HalfInteger) = HalfIntegerRange(i, j)
+
+export HalfInteger, @hi_str

--- a/src/jj2lsj.jl
+++ b/src/jj2lsj.jl
@@ -57,7 +57,7 @@ function rotate!(block::M, orbs::RelativisticOrbital...) where {T,M<:AbstractMat
     # We sort by mⱼ and remove the first and last elements since they
     # are pure and trivially unity.
     ℓms = vcat([[(ℓ,m,s) for m ∈ -ℓ:ℓ] for s = -1//2:1//2]...)[2:end-1]
-    jmⱼ = sort(vcat([[(j,mⱼ) for mⱼ ∈ -j:j] for j ∈ [o.j for o in orbs]]...), by=last)[2:end-1]
+    jmⱼ = sort(vcat([[(j,mⱼ) for mⱼ ∈ -j:j] for j ∈ [convert(Rational, o.j) for o in orbs]]...), by=last)[2:end-1]
     for (a,(ℓ,m,s)) in enumerate(ℓms)
         for (b,(j,mⱼ)) in enumerate(jmⱼ)
             block[a,b] = ClebschGordanℓs(ℓ,m,1//2,s,j,mⱼ)
@@ -99,11 +99,11 @@ function jj2lsj(::Type{T}, orbs::RelativisticOrbital...) where T
         i = findall(isequal((n,ℓ)), nℓs)
         subspace = orbs[i]
         mⱼ = map(subspace) do orb
-            j = orb.j
+            j = convert(Rational, orb.j)
             -j:j
         end
 
-        jₘₐₓ = maximum([o.j for o in subspace])
+        jₘₐₓ = maximum([convert(Rational, o.j) for o in subspace])
         pure = [Matrix{T}(undef,1,1),Matrix{T}(undef,1,1)]
         pure[1][1]=ClebschGordanℓs(ℓ,-ℓ,1//2,-1//2,jₘₐₓ,-jₘₐₓ)
         pure[2][1]=ClebschGordanℓs(ℓ,ℓ,1//2,1//2,jₘₐₓ,jₘₐₓ)

--- a/src/jj_terms.jl
+++ b/src/jj_terms.jl
@@ -1,8 +1,7 @@
-couple_terms(J1::N, J2::N) where {I<:Integer,R<:Rational{I},N<:Union{I,R}} =
+couple_terms(J1::T, J2::T) where {T <: Union{Integer,HalfInteger}} =
     collect(abs(J1-J2):(J1+J2))
-
-function couple_terms(J::Vector{N}, j₀::N=zero(N)) where {I<:Integer,R<:Rational{I},N<:Union{I,R}}
-    ts = Vector{Vector{N}}()
+function couple_terms(J::Vector{T}, j₀::T=zero(T)) where {T <: Union{Integer,HalfInteger}}
+    ts = Vector{Vector{T}}()
     for t in couple_terms(j₀, J[1])
         if length(J) == 1
             push!(ts, [j₀, t])
@@ -15,19 +14,25 @@ function couple_terms(J::Vector{N}, j₀::N=zero(N)) where {I<:Integer,R<:Ration
     ts
 end
 
+couple_terms(J1::Real, J2::Real) =
+    couple_terms(convert(HalfInteger, J1), convert(HalfInteger, J2))
+couple_terms(J::Vector{T}, j₀::Real=zero(T)) where {T <: Real} =
+    couple_terms(convert.(HalfInteger, J), convert(HalfInteger, j₀))
+
 function jj_terms(orb::RelativisticOrbital, w::Int=one(Int))
     @unpack ℓ,j = orb
+    w <= 2j+1 || throw(ArgumentError("w=$w too large for $orb orbital"))
 
-    2w ≥ 2j+1 && (w = 2j+1-w)
-    w == 0 && return [zero(Rational{Int})]
+    2w ≥ 2j+1 && (w = convert(Int, 2j) + 1 - w)
+    w == 0 && return [zero(HalfInteger)]
     w == 1 && return [j]
 
     # Forms full Cartesian product of all mⱼ, not necessarily the most
     # performant method.
     mⱼs = filter(allunique, collect(allchoices([-j:j for i = 1:w])))
-    MJs = map(sum, mⱼs)
+    MJs = map(x -> reduce(+, x), mⱼs) # TODO: make map(sum, mⱼs) work
 
-    Js = Rational{Int}[]
+    Js = HalfInteger[]
 
     while !isempty(MJs)
         # Identify the maximum MJ and associate it with J.

--- a/src/orbitals.jl
+++ b/src/orbitals.jl
@@ -40,8 +40,9 @@ end
 
 # * Relativistic orbital
 
-function check_orbital_ℓj(ℓ::Int, j::R) where {R<:Rational{Int}}
-    s = R(1,2)
+function check_orbital_ℓj(ℓ::Int, j::Real)
+    j = HalfInteger(j)
+    s = hi"1/2"
     j₋ = abs(ℓ - s)
     j₊ = ℓ+s
     j ∈ j₋:j₊ || throw(ArgumentError("Invalid j = $(j) ∉ $(j₋):$(j₊)"))
@@ -50,14 +51,14 @@ end
 struct RelativisticOrbital{N<:MQ} <: AbstractOrbital
     n::N
     ℓ::Int
-    j::Rational{Int}
-    function RelativisticOrbital(n::Int, ℓ::Int, j::R=ℓ+Rational{Int}(1,2)) where {R<:Rational{Int}}
+    j::HalfInteger
+    function RelativisticOrbital(n::Int, ℓ::Int, j::Real=ℓ+hi"1/2")
         n ≥ 1 || throw(ArgumentError("Invalid main quantum number $(n)"))
         0 ≤ ℓ && ℓ < n || throw(ArgumentError("Angular quantum number has to be ∈ [0,$(n-1)] when n = $(n)"))
         check_orbital_ℓj(ℓ, j)
         new{Int}(n, ℓ, j)
     end
-    function RelativisticOrbital(n::Symbol, ℓ::Int, j::R=ℓ+Rational{Int}(1,2)) where {R<:Rational{Int}}
+    function RelativisticOrbital(n::Symbol, ℓ::Int, j::Real=ℓ+hi"1/2")
         check_orbital_ℓj(ℓ, j)
         new{Symbol}(n, ℓ, j)
     end
@@ -71,7 +72,7 @@ end
 flip_j(orb::RelativisticOrbital) =
     RelativisticOrbital(orb.n, orb.ℓ, orb.ℓ > 0 ? orb.ℓ - (orb.j - orb.ℓ) : orb.j)
 
-degeneracy(orb::RelativisticOrbital{N}) where N = 2orb.j + 1 |> Int
+degeneracy(orb::RelativisticOrbital{N}) where N = convert(Int, 2*orb.j) + 1
 
 function Base.isless(a::RelativisticOrbital, b::RelativisticOrbital)
     nisless(a.n, b.n) && return true

--- a/test/halfinteger.jl
+++ b/test/halfinteger.jl
@@ -1,0 +1,88 @@
+# Largely borrowed from WignerSymbols.jl (https://github.com/Jutho/WignerSymbols.jl)
+# Copyright (c) 2017: Jutho Haegeman; MIT "Expat" License
+
+@testset "HalfInteger" begin
+    @testset "HalfInteger type" begin
+        @test convert(HalfInteger, 2) == HalfInteger(twoX = 4)
+        @test convert(HalfInteger, 1//2) == HalfInteger(twoX = 1)
+        @test convert(HalfInteger, 1.5) == HalfInteger(twoX = 3)
+        @test_throws InexactError convert(HalfInteger, 1//3)
+        @test_throws InexactError convert(HalfInteger, 0.6)
+        @test convert(HalfInteger, 2) == 2
+        @test convert(HalfInteger, 1//2) == 1//2
+        @test convert(HalfInteger, 1.5) == 1.5
+        @test_throws InexactError convert(Integer, HalfInteger(1//2))
+        a = HalfInteger(2)
+        b = HalfInteger(3//2)
+        @test a + b == 2 + 3//2
+        @test a - b == 2 - 3//2
+        @test zero(a) == 0
+        @test one(a) == 1
+        @test a > b
+        @test b < a
+        @test b <= a
+        @test a >= b
+        @test a == a
+        @test a != b
+
+        @test 2 * a == HalfInteger(4)
+        @test (-1) * b == HalfInteger(-3//2)
+
+        @test HalfInteger(0) == HalfInteger(twoX = 0)
+        @test HalfInteger(1) == HalfInteger(twoX = 2)
+        @test HalfInteger(2) == HalfInteger(twoX = 4)
+        @test HalfInteger(-30) == HalfInteger(twoX = -60)
+        @test HalfInteger(0//2) == HalfInteger(twoX = 0)
+        @test HalfInteger(1//2) == HalfInteger(twoX = 1)
+        @test HalfInteger(-5//2) == HalfInteger(twoX = -5)
+
+        @test hi"0" == HalfInteger(0)
+        @test hi"1" == HalfInteger(1)
+        @test hi"210938" == HalfInteger(210938)
+        @test hi"-15" == HalfInteger(-15)
+        @test hi"1/2" == HalfInteger(1//2)
+        @test hi"-3/2" == HalfInteger(-3//2)
+
+        @test string(hi"0") == "0"
+        @test string(hi"1") == "1"
+        @test string(hi"-1") == "-1"
+        @test string(hi"1/2") == "1/2"
+        @test string(hi"-3/2") == "-3/2"
+
+        @test_throws ArgumentError parse(HalfInteger, "")
+        @test_throws ArgumentError parse(HalfInteger, "-50/100")
+        @test_throws ArgumentError parse(HalfInteger, "1/3")
+
+        @test hash(a) == hash(2)
+        @test hash(b) == hash(1.5)
+        @test hash(b) == hash(3//2)
+    end
+
+    @testset "HalfIntegerRange" begin
+        using AtomicLevels: HalfIntegerRange
+        @test length(HalfIntegerRange(hi"0", hi"0")) == 1
+        @test length(HalfIntegerRange(hi"0", hi"2")) == 3
+        @test length(HalfIntegerRange(hi"-1/2", hi"1/2")) == 2
+        @test size(HalfIntegerRange(hi"-1/2", hi"1/2")) == (2,)
+
+        @test hi"5" : hi"7" == HalfIntegerRange(HalfInteger(5), HalfInteger(7))
+        @test hi"-1/2" : hi"1/2" == HalfIntegerRange(hi"-1/2", hi"1/2")
+
+        @test collect(hi"0" : hi"2") == [hi"0", hi"1", hi"2"]
+        @test collect(hi"-3/2" : hi"1/2") == [hi"-3/2", hi"-1/2", hi"1/2"]
+
+        @test hi"1/2" ∈ hi"-1/2" : hi"1/2"
+        @test 1 ∈ hi"0" : hi"2"
+        @test 1//2 ∈ hi"-1/2" : hi"7/2"
+        @test !(hi"1/2" ∈ hi"0" : hi"1")
+        @test !(1//2 ∈ hi"-1" : hi"7")
+
+        r = hi"-3/2" : hi"3/2"
+        @test r[1] == hi"-3/2"
+        @test r[2] == hi"-1/2"
+        @test r[3] == hi"1/2"
+        @test r[4] == hi"3/2"
+        @test_throws BoundsError r[0]
+        @test_throws BoundsError r[5]
+    end
+end

--- a/test/jj_terms.jl
+++ b/test/jj_terms.jl
@@ -16,10 +16,10 @@
         ]) do (orbs,wsj)
             foreach(orbs) do orb
                 foreach(wsj) do (ws,j)
-                    j isa Number && (j = j:j)
+                    js = map(HalfInteger, isa(j, Number) ? [j] : j)
                     foreach(ws) do w
                         # Should actually test without unique
-                        @test unique(jj_terms(orb,w)) == unique(j)
+                        @test unique(jj_terms(orb,w)) == unique(js)
                     end
                 end
             end
@@ -27,9 +27,28 @@
     end
 
     @testset "Coupling of jj terms" begin
+        @test couple_terms(1, 2) isa Vector{Int}
+        @test couple_terms(1//2, 1//2) isa Vector{HalfInteger}
+        @test couple_terms(1.0, 1.5) isa Vector{HalfInteger}
+
+        @test couple_terms(hi"1/2", hi"0") == [1//2]
+        @test couple_terms(1//2, hi"0") == [1//2]
+        @test couple_terms(hi"1/2", 0) == [1//2]
+
         @test couple_terms(0, 1) == 1:1
         @test couple_terms(1//2,1//2) == 0:1
         @test couple_terms(1, 1) == 0:2
         @test couple_terms(1//1, 3//2) == 1//2:5//2
+
+        @test couple_terms(0, 1.0) == 1:1
+        @test couple_terms(1.0, 1.5) == 1//2:5//2
+
+        @test couple_terms([1, 2], 3) isa Vector{Vector{Int}}
+        @test couple_terms([1, 2], hi"3") isa Vector{Vector{HalfInteger}}
+        @test couple_terms([1, 2.5], 3) isa Vector{Vector{HalfInteger}}
+
+        @test couple_terms([0, 0], 0) == [[0,0,0]]
+        @test couple_terms([0, 0], 1) == [[1,1,1]]
+        @test couple_terms([1//2, 1//2], 0) == [[0,1//2,0],[0,1//2,1]]
     end
 end

--- a/test/orbitals.jl
+++ b/test/orbitals.jl
@@ -7,6 +7,7 @@ using Random
         @test o"2[1]" == Orbital(2,1)
 
         @test ro"1s" == RelativisticOrbital(1,0)
+        @test ro"2p-" == RelativisticOrbital(2,1,hi"1/2")
         @test ro"2p-" == RelativisticOrbital(2,1,1//2)
         @test ro"2p" == RelativisticOrbital(2,1,3//2)
         @test ro"2[1]" == RelativisticOrbital(2,1,3//2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using AtomicLevels
 using Test
 
 include("parity.jl")
+include("halfinteger.jl")
 include("orbitals.jl")
 include("configurations.jl")
 include("excited_configurations.jl")

--- a/test/terms.jl
+++ b/test/terms.jl
@@ -55,7 +55,7 @@ using Test
     end
 
     @testset "Orbital terms" begin
-        function test_single_orbital_terms(orb::Orbital, occ::Int, ts::Vector{Term{LT}}) where LT
+        function test_single_orbital_terms(orb::Orbital, occ::Int, ts::Vector{Term})
             cts = sort(terms(orb, occ))
             ts = sort(ts)
             ccts = copy(cts)
@@ -75,7 +75,7 @@ using Test
             @test length(ts) == 0
         end
 
-        function test_single_orbital_terms(orb::Orbital, occs::Tuple{Int,Int}, ts::Vector{Term{LT}}) where LT
+        function test_single_orbital_terms(orb::Orbital, occs::Tuple{Int,Int}, ts::Vector{Term})
             map(occs) do occ
                 test_single_orbital_terms(orb, occ, ts)
             end


### PR DESCRIPTION
Switches `Term`, `CSF` and `RelativisticOrbital` over to `HalfInteger`. This is possibly still pretty WIP -- I got the tests to pass, but there might still be some inconsistencies.

For the `HalfInteger`, I rolled our own version of the type for now, since I needed to extend it and I didn't want to commit type piracy. I also e.g. changed how the constructor behaves. At some point, it would be great to commit this back upstream though.

Closes #7.