### PR TITLE
Fix regex for orbital parsing in configurations

### DIFF
--- a/src/configurations.jl
+++ b/src/configurations.jl
@@ -169,8 +169,8 @@ function core_configuration(::Type{O}, element::AbstractString, state::AbstractS
 end
 
 function parse_orbital(::Type{O}, orb_str) where {O<:AbstractOrbital}
-    m = match(r"^([0-9]+|.([a-z]|\[[0-9]+\])[-]{0,1})([0-9]*)([*ci]{0,1})$",orb_str)
-    orbital_from_string(O, m[1]),m[3]=="" ? 1 : parse(Int, m[3]),state_sym(m[4])
+    m = match(r"^(([0-9]+|.)([a-z]|\[[0-9]+\])[-]{0,1})([0-9]*)([*ci]{0,1})$", orb_str)
+    orbital_from_string(O, m[1]) , (m[4] == "") ? 1 : parse(Int, m[4]), state_sym(m[5])
 end
 
 function Base.parse(::Type{Configuration{O}}, conf_str::AbstractString) where {O<:AbstractOrbital}

--- a/test/configurations.jl
+++ b/test/configurations.jl
@@ -42,6 +42,10 @@
         @test fill(rc"1s 2s 2p- 2p") == rc"1s2 2s2 2p-2 2p4"
         @test close(c"1s2") == c"1s2c"
         @test_throws ArgumentError close(c"1s")
+
+        # Tests for #19
+        @test c"10s2" == Configuration([o"10s"], [2], [:open])
+        @test c"9999l32" == Configuration([o"9999l"], [32], [:open])
     end
 
     @testset "Number of electrons" begin


### PR DESCRIPTION
Adds another set of parentheses to group the n quantum number part properly, fixing #19.

* Do I understand correctly that instead of an integer, the "n quantum number" could also be a single arbitrary character? Should the class be restricted to something perhaps?

* And the angular part is either (a) a single `a-z` character, interpreted as the spectroscopic label, or (b) an integer surrounded by square brackets?