### PR TITLE
Add Documenter-based documentation deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .juliahistory
 .ipynb_checkpoints
 ltxpng
+
+docs/build/
+docs/Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,14 @@ after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
+                                               Pkg.instantiate()'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "~0.21"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,10 @@
+using Documenter
+
+makedocs(
+    sitename = "AtomicLevels",
+    pages = [
+        "Home" => "index.md",
+    ],
+)
+
+deploydocs(repo = "github.com/JuliaAtoms/AtomicLevels.jl.git")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,1 @@
+# AtomicLevels.jl


### PR DESCRIPTION
I am opening this against `master` at the moment so that I wouldn't have to worry about the branch names. Should be easy to merge with `revamp`.