### PR TITLE
Hashing and reduction of configurations

### DIFF
--- a/docs/src/configurations.md
+++ b/docs/src/configurations.md
@@ -77,6 +77,7 @@ inactive
 bound
 continuum
 parity(::Configuration)
+nonrelconfiguration
 ```
 
 ## Generating configuration lists

--- a/src/configurations.jl
+++ b/src/configurations.jl
@@ -106,6 +106,8 @@ issimilar(a::Configuration{<:O}, b::Configuration{<:O}) where {O<:AbstractOrbita
 Base.:(==)(a::Configuration{<:O}, b::Configuration{<:O}) where {O<:AbstractOrbital} =
     issimilar(a, b) && a.states == b.states
 
+Base.hash(c::Configuration) = hash(c.orbitals) ⊻ hash(c.occupancy) ⊻ hash(c.states)
+
 """
     fill(c::Configuration)
 

--- a/src/orbitals.jl
+++ b/src/orbitals.jl
@@ -30,6 +30,13 @@ momentum `ℓ`.
 The type parameter `N` has to be such that it can represent a proper principal quantum number
 (i.e. a subtype of [`AtomicLevels.MQ`](@ref)).
 
+# Properties
+
+The following properties are part of the public API:
+
+* `.n :: N` -- principal quantum number ``n``
+* `.ℓ :: Int` -- the orbital angular momentum ``\\ell``
+
 # Constructors
 
     Orbital(n::Int, ℓ::Int)
@@ -295,6 +302,29 @@ When printing and parsing `RelativisticOrbital`s, the notation `nℓ` and `nℓ-
 The type parameter `N` has to be such that it can represent a proper principal quantum number
 (i.e. a subtype of [`AtomicLevels.MQ`](@ref)).
 
+# Properties
+
+The following properties are part of the public API:
+
+* `.n :: N` -- principal quantum number ``n``
+* `.κ :: Int` -- ``\\kappa`` quantum number
+* `.ℓ :: Int` -- the orbital angular momentum label ``\\ell``
+* `.j :: HalfInteger` -- total angular momentum ``j``
+
+```jldoctest
+julia> orb = ro"5g-"
+5g⁻
+
+julia> orb.n
+5
+
+julia> orb.j
+7/2
+
+julia> orb.ℓ
+4
+```
+
 # Constructors
 
     RelativisticOrbital(n::Integer, κ::Integer)
@@ -334,6 +364,12 @@ struct RelativisticOrbital{N<:MQ} <: AbstractOrbital
 end
 RelativisticOrbital(n::MQ, ℓ::Integer, j::Real) = RelativisticOrbital(n, ℓj_to_kappa(ℓ, j))
 
+Base.propertynames(::RelativisticOrbital) = (fieldnames(RelativisticOrbital)..., :j, :ℓ)
+function Base.getproperty(o::RelativisticOrbital, s::Symbol)
+    s === :j ? kappa_to_j(o.κ) :
+    s === :ℓ ? kappa_to_ℓ(o.κ) :
+    getfield(o, s)
+end
 
 function Base.show(io::IO, orb::RelativisticOrbital)
     write(io, "$(orb.n)$(spectroscopic_label(kappa_to_ℓ(orb.κ)))")

--- a/src/orbitals.jl
+++ b/src/orbitals.jl
@@ -67,6 +67,13 @@ struct Orbital{N<:MQ} <: AbstractOrbital
     end
 end
 
+"""
+    mqtype(::Orbital{MQ}) = MQ
+
+Returns the main quantum number type of an [`Orbital`](@ref).
+"""
+mqtype(::Orbital{MQ}) where MQ = MQ
+
 Base.show(io::IO, orb::Orbital{N}) where N =
     write(io, "$(orb.n)$(spectroscopic_label(orb.ℓ))")
 
@@ -363,6 +370,13 @@ struct RelativisticOrbital{N<:MQ} <: AbstractOrbital
     end
 end
 RelativisticOrbital(n::MQ, ℓ::Integer, j::Real) = RelativisticOrbital(n, ℓj_to_kappa(ℓ, j))
+
+"""
+    mqtype(::RelativisticOrbital{MQ}) = MQ
+
+Returns the main quantum number type of a [`RelativisticOrbital`](@ref).
+"""
+mqtype(::RelativisticOrbital{MQ}) where MQ = MQ
 
 Base.propertynames(::RelativisticOrbital) = (fieldnames(RelativisticOrbital)..., :j, :ℓ)
 function Base.getproperty(o::RelativisticOrbital, s::Symbol)

--- a/test/configurations.jl
+++ b/test/configurations.jl
@@ -358,6 +358,12 @@
                                 [SpinOrbital(o"1s",0,true)=>SpinOrbital(o"ks",0,true)]
     end
 
+    @testset "Configuration transformations" begin
+        @test nonrelconfiguration(rc"1s2 2p-2 2s 2p2 3s2 3p-") == c"1s2 2s 2p4 3s2 3p"
+        @test nonrelconfiguration(rc"1s2 ks2") == c"1s2 ks2"
+        @test nonrelconfiguration(rc"kp-2 kp4 lp-2 lp") == c"kp6 lp3"
+    end
+
     @testset "Internal utilities" begin
         @test AtomicLevels.get_noble_core_name(c"1s2 2s2 2p6") === nothing
         @test AtomicLevels.get_noble_core_name(c"1s2c 2s2 2p6") === "He"

--- a/test/configurations.jl
+++ b/test/configurations.jl
@@ -61,6 +61,23 @@
         # Tests for #19
         @test c"10s2" == Configuration([o"10s"], [2], [:open])
         @test c"9999l32" == Configuration([o"9999l"], [32], [:open])
+
+        # Hashing
+        let c1a = c"1s 2s", c1b = c"1s 2s", c2 = c"1s 2p"
+            @test c1a == c1b
+            @test isequal(c1a, c1b)
+            @test c1a != c2
+            @test !isequal(c1a, c2)
+
+            @test hash(c1a) == hash(c1a)
+            @test hash(c1a) == hash(c1b)
+
+            # If hashing is not properly implemented, unique fails to detect all equal pairs
+            @test unique([c1a, c1b]) == [c1a]
+            @test unique([c1a, c1a]) == [c1a]
+            @test unique([c1a, c1a, c1b]) == [c1a]
+            @test length(unique([c1a, c2, c1a, c1b, c2])) == 2
+        end
     end
 
     @testset "Number of electrons" begin

--- a/test/orbitals.jl
+++ b/test/orbitals.jl
@@ -78,6 +78,39 @@ using Random
         @test_throws ArgumentError RelativisticOrbital(1, 0, 3//2)
     end
 
+    @testset "Properties" begin
+        let o = o"3d"
+            @test o.n == 3
+            @test o.ℓ == 2
+        end
+        let o = o"ks"
+            @test o.n == :k
+            @test o.ℓ == 0
+        end
+
+        @test propertynames(o"1s") == (:n , :ℓ)
+        @test propertynames(ro"1s") == (:n, :κ, :j, :ℓ)
+
+        let o = ro"3d"
+            @test o.n == 3
+            @test o.κ == -3
+            @test o.j == 5//2
+            @test o.ℓ == 2
+        end
+        let o = ro"ks"
+            @test o.n == :k
+            @test o.κ == -1
+            @test o.j == 1//2
+            @test o.ℓ == 0
+        end
+        let o = ro"2p-"
+            @test o.n == 2
+            @test o.κ == 1
+            @test o.j == 1//2
+            @test o.ℓ == 1
+        end
+    end
+
     @testset "Order" begin
         @test sort(shuffle([o"1s", o"2s", o"2p", o"3s", o"3p"])) ==
             [o"1s", o"2s", o"2p", o"3s", o"3p"]

--- a/test/orbitals.jl
+++ b/test/orbitals.jl
@@ -261,4 +261,11 @@ using Random
         @test "$(soα)" == "1s₀α"
         @test "$(po₊β)" == "2p₁β"
     end
+
+    @testset "Internal methods" begin
+        @test AtomicLevels.mqtype(o"2s") == Int
+        @test AtomicLevels.mqtype(o"ks") == Symbol
+        @test AtomicLevels.mqtype(ro"2s") == Int
+        @test AtomicLevels.mqtype(ro"ks") == Symbol
+    end
 end


### PR DESCRIPTION
* The `hash(::Configuration)` makes sure that "`isequal(x,y)` therefore `hash(x) == hash(y)`" holds, which is important for `unique` to work properly with lists of configurations.
* Defines the _properties_ of orbitals that are part of the public API. Adds a computed `.ℓ` and `.j` property to `RelativisticOrbital`, since these are often used.
* Adds a function to reduce relativistic configurations back down to the corresponding non-relativistic orbitals by combining the `nℓ-` and `nℓ` shells.