### PR TITLE
Don't run CI twice for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,17 @@ notifications:
 git:
   depth: 99999999
 
+branches:
+  only:
+    - master
+    - /release-.*/
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
-matrix:
- allow_failures:
- - julia: nightly
+# matrix:
+#  allow_failures:
+#  - julia: nightly
 
 ## uncomment and modify the following lines to manually install system packages
 #addons:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,11 @@ platform:
 #   allow_failures:
 #   - julia_version: nightly
 
-# branches:
-#   only:
-#     - master
-#     - /release-.*/
+branches:
+  only:
+    - master
+    - /release-.*/
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 
 notifications:
   - provider: Email


### PR DESCRIPTION
Also, fail Travis on nightly failures. Appveyor already does anyway.