### PR TITLE
Added ASCII representations for orbitals and configurations

### DIFF
--- a/src/orbitals.jl
+++ b/src/orbitals.jl
@@ -19,6 +19,13 @@ nisless(an::T, bn::T) where T = an < bn
 nisless(an::I, bn::Symbol) where {I<:Integer} = true
 nisless(an::Symbol, bn::I) where {I<:Integer} = false
 
+function Base.ascii(o::AbstractOrbital)
+    io = IOBuffer()
+    ctx = IOContext(io, :ascii=>true)
+    show(ctx, o)
+    String(take!(io))
+end
+
 # * Non-relativistic orbital
 
 """
@@ -387,7 +394,7 @@ end
 
 function Base.show(io::IO, orb::RelativisticOrbital)
     write(io, "$(orb.n)$(spectroscopic_label(kappa_to_ℓ(orb.κ)))")
-    orb.κ > 0 && write(io, "⁻")
+    orb.κ > 0 && write(io, get(io, :ascii, false) ? "-" : "⁻")
 end
 
 function flip_j(orb::RelativisticOrbital)

--- a/test/configurations.jl
+++ b/test/configurations.jl
@@ -434,4 +434,11 @@
             end
         end
     end
+
+    @testset "String representation" begin
+        @test string(c"[Ar]c 3d10c 4s2c 4p6 4d10 5s2i 5p6") == "[Ar]ᶜ 3d¹⁰ᶜ 4s²ᶜ 4p⁶ 4d¹⁰ 5s²ⁱ 5p⁶"
+        @test ascii(c"[Ar]c 3d10c 4s2c 4p6 4d10 5s2i 5p6") == "[Ar]c 3d10c 4s2c 4p6 4d10 5s2i 5p6"
+        @test string(rc"[Ar]*") == "1s² 2s² 2p⁴ 2p⁻² 3s² 3p⁴ 3p⁻²"
+        @test ascii(rc"[Ar]*") == "1s2 2s2 2p4 2p-2 3s2 3p4 3p-2"
+    end
 end

--- a/test/orbitals.jl
+++ b/test/orbitals.jl
@@ -270,4 +270,10 @@ using Random
         @test AtomicLevels.mqtype(ro"2s") == Int
         @test AtomicLevels.mqtype(ro"ks") == Symbol
     end
+
+    @testset "String representation" begin
+        @test string(o"1s") == "1s"
+        @test string(ro"2p-") == "2p⁻"
+        @test ascii(ro"2p-") == "2p-"
+    end
 end


### PR DESCRIPTION
Still need to fix printing of spin-configurations after the unsorted debacle and introduce ASCII representations of those.