### PR TITLE
Updates to (intermediate) terms

### DIFF
--- a/docs/src/terms.md
+++ b/docs/src/terms.md
@@ -75,7 +75,7 @@ intermediate_terms
 ### Disambiguating quantum numbers
 
 The [`IntermediateTerm`](@ref) type does not specify how to interpret the disambiguating
-quantum number ``ν``, or even what the type of it should be. In AtomicLevels, we use it two
+quantum number(s) ``ν``, or even what the type of it should be. In AtomicLevels, we use two
 different types, depending on the situation:
 
 * **A simple `Integer`.** In this case, the quantum number ``\nu`` must be in the range
@@ -87,7 +87,7 @@ different types, depending on the situation:
   It can be used as a simple counter to distinguish the different terms, or the user can
   define their own mapping from the set of integers to physical states.
 
-* **`Seniority`.** In this case the number is intepreted to be _Racah's seniority
+* **`Seniority`.** In this case the number is interpreted to be _Racah's seniority
   number_. This gives the intermediate term a specific physical interpretation, but only
   works for certain subshells. See the [`Seniority`](@ref) type for more information.
 

--- a/docs/src/terms.md
+++ b/docs/src/terms.md
@@ -1,15 +1,13 @@
 # Term symbols
 
 ```@meta
-DocTestSetup = quote
-    using AtomicLevels
-end
+DocTestSetup = :(using AtomicLevels)
 ```
 
 AtomicLevels provides types and methods to work and determine term symbols. The ["Term
 symbol"](https://en.wikipedia.org/wiki/Term_symbol) and ["Angular momentum
-coupling"](https://en.wikipedia.org/wiki/Angular_momentum_coupling) Wikipedia articles give a good basic
-overview of the terminology.
+coupling"](https://en.wikipedia.org/wiki/Angular_momentum_coupling) Wikipedia articles give
+a good basic overview of the terminology.
 
 For term symbols in LS coupling, AtomicLevels provides the [`Term`](@ref) type.
 
@@ -21,11 +19,12 @@ The [`Term`](@ref) objects can also be constructed with the [`@T_str`](@ref) str
 
 ```@docs
 @T_str
+Base.parse(::Type{Term}, ::AbstractString)
 ```
 
 The [`terms`](@ref) function can be used to generate all possible term symbols. In the case
 of relativistic orbitals, the term symbols are simply the valid ``J`` values, represented
-with the `HalfInteger` type.
+using the [`HalfInteger`](https://github.com/sostock/HalfIntegers.jl) type.
 
 ```@docs
 terms

--- a/docs/src/terms.md
+++ b/docs/src/terms.md
@@ -28,32 +28,71 @@ using the [`HalfInteger`](https://github.com/sostock/HalfIntegers.jl) type.
 
 ```@docs
 terms
+count_terms
 ```
 
 ## Term multiplicity and intermediate terms
 
-For subshells starting with `d³`, the possible terms may occur more
-than once (multiplicity higher than one), corresponding to different
-physical states. These arise from different sequences of coupling the
-``w`` equivalent electrons of the same ``\ell``, and are distinguished
-using a _seniority number_, which the [`IntermediateTerm`](@ref) type
-implements. For partially filled `f` shells, seniority is not enough
-to distinguish all possible couplings. Using `count_terms`, we can see
-that e.g. the `²Dᵒ` has higher multiplicity than can be described with
-seniority only:
+For subshells starting with `d³`, a term symbol can occur multiple times, each occurrence
+corresponding to a different physical state (multiplicity higher than one). This happens
+when there are distinct ways of coupling the electrons, but they yield the same total
+angular momentum. E.g. a `d³` subshell can be coupled in 8 different ways, two of which are
+both described by the `²D` term symbol:
 
 ```jldoctest
-julia> count_terms(o"4f", 3, T"2Do")
-2
+julia> terms(o"3d", 3)
+8-element Array{Term,1}:
+ ²P
+ ²D
+ ²D
+ ²F
+ ²G
+ ²H
+ ⁴P
+ ⁴F
 
+julia> count_terms(o"3d", 3, T"2D")
+2
+```
+
+The multiplicity can be even higher if more electrons and higher angular momenta are
+involved:
+
+```jldoctest
 julia> count_terms(o"4f", 5, T"2Do")
 5
 ```
 
+To distinguish these subshells, extra quantum numbers must be specified. In AtomicLevels,
+that can be done with the [`IntermediateTerm`](@ref) type. This is primarily used when
+specifying the subshell couplings in [CSFs](@ref).
+
 ```@docs
 IntermediateTerm
 intermediate_terms
-count_terms
+```
+
+### Disambiguating quantum numbers
+
+The [`IntermediateTerm`](@ref) type does not specify how to interpret the disambiguating
+quantum number ``ν``, or even what the type of it should be. In AtomicLevels, we use it two
+different types, depending on the situation:
+
+* **A simple `Integer`.** In this case, the quantum number ``\nu`` must be in the range
+  ``1 \leq \nu \leq N_{\rm{terms}}``, where ``N_{\rm{terms}}`` is the multiplicity of the
+  term symbol (i.e. the number of times this term symbol appears for this subshell
+  ``\ell^w`` or ``\ell_j^w``).
+
+  AtomicLevels does not prescribe any further interpretation for the quantum number.
+  It can be used as a simple counter to distinguish the different terms, or the user can
+  define their own mapping from the set of integers to physical states.
+
+* **`Seniority`.** In this case the number is intepreted to be _Racah's seniority
+  number_. This gives the intermediate term a specific physical interpretation, but only
+  works for certain subshells. See the [`Seniority`](@ref) type for more information.
+
+```@docs
+Seniority
 ```
 
 ### Internal implementation of term multiplicity calculation
@@ -62,10 +101,9 @@ AtomicLevels.jl uses the algorithm presented in
 
 - _Alternative mathematical technique to determine LS spectral terms_
   by Xu Renjun and Dai Zhenwen, published in JPhysB, 2006.
-
   [doi:10.1088/0953-4075/39/16/007](https://dx.doi.org/10.1088/0953-4075/39/16/007)
 
-to compute the multiplicity of individual subshells, beyond the
+to compute the multiplicity of individual subshells in ``LS``-coupling, beyond the
 trivial cases of a single electron or a filled subshell. These
 routines need not be used directly, instead use [`terms`](@ref) and
 [`count_terms`](@ref).

--- a/src/intermediate_terms.jl
+++ b/src/intermediate_terms.jl
@@ -61,12 +61,45 @@ end
 
 # * Intermediate terms, seniority
 """
+    struct IntermediateTerm{T,S}
+
+Represents a term together with its extra disambiguating quantum number, labelled by `ν`.
+
+The term symbol (`::T`) can either be a [`Term`](@ref) (for ``LS``-coupling) or a
+`HalfInteger` (for ``jj``-coupling).
+
+The disambiguating quantum number (`::S`) can be anything as long is it is sortable (i.e.
+implementing `isless`). It is up to the user to pick a scheme that is suitable for their
+application. See "[Disambiguating quantum numbers](@ref)" in the manual for discussion on how
+it is used in AtomicLevels.
+
+See also: [`Term`](@ref), [`Seniority`](@ref)
+
+# Constructors
+
     IntermediateTerm(term, ν)
 
-Represents a `term` together with its extra disambiguating quantum
-numbers, labelled by `ν`, which should be sortable (i.e. comparable by
-`isless`). The most common implementation of this is a single quantum
-number, [`Seniority`](@ref).
+Constructs and intermediate term with term symbol `term` and disambiguating quantum number
+`ν`.
+
+# Properties
+
+To access the term symbol and the disambiguating quantum number, you can use the
+`.term :: T` and `.ν :: S` (or `.nu :: S`) properties, respectively. E.g.:
+
+```jldoctest
+julia> it = IntermediateTerm(T"2D", 2)
+₍₂₎²D
+
+julia> it.term, it.ν
+(²D, 2)
+
+julia> it = IntermediateTerm(5//2, Seniority(2))
+₂5/2
+
+julia> it.term, it.nu
+(5/2, ₂)
+```
 """
 struct IntermediateTerm{T,S}
     term::T

--- a/src/intermediate_terms.jl
+++ b/src/intermediate_terms.jl
@@ -68,10 +68,10 @@ Represents a term together with its extra disambiguating quantum number(s), labe
 The term symbol (`::T`) can either be a [`Term`](@ref) (for ``LS``-coupling) or a
 `HalfInteger` (for ``jj``-coupling).
 
-The disambiguating quantum number(s) (`::S`) can be anything as long is it is sortable (i.e.
-implementing `isless`). It is up to the user to pick a scheme that is suitable for their
-application. See "[Disambiguating quantum numbers](@ref)" in the manual for discussion on
-how it is used in AtomicLevels.
+The disambiguating quantum number(s) (`::S`) can be anything as long as they are sortable
+(i.e. implementing `isless`). It is up to the user to pick a scheme that is suitable for
+their application. See "[Disambiguating quantum numbers](@ref)" in the manual for discussion
+on how it is used in AtomicLevels.
 
 See also: [`Term`](@ref), [`Seniority`](@ref)
 
@@ -79,7 +79,7 @@ See also: [`Term`](@ref), [`Seniority`](@ref)
 
     IntermediateTerm(term, ν)
 
-Constructs and intermediate term with term symbol `term` and disambiguating quantum
+Constructs an intermediate term with the term symbol `term` and disambiguating quantum
 number(s) `ν`.
 
 # Properties

--- a/src/intermediate_terms.jl
+++ b/src/intermediate_terms.jl
@@ -77,6 +77,9 @@ struct IntermediateTerm{T,S}
         IntermediateTerm(convert(HalfInt, term), ν)
 end
 
+Base.getproperty(it::IntermediateTerm, s::Symbol) = s == :nu ? getfield(it, :ν) : getfield(it, s)
+Base.propertynames(::IntermediateTerm, private=false) = (:term, :ν, :nu)
+
 function Base.show(io::IO, iterm::IntermediateTerm{<:Any,<:Integer})
     write(io, "₍")
     write(io, to_subscript(iterm.ν))

--- a/src/intermediate_terms.jl
+++ b/src/intermediate_terms.jl
@@ -63,15 +63,15 @@ end
 """
     struct IntermediateTerm{T,S}
 
-Represents a term together with its extra disambiguating quantum number, labelled by `ν`.
+Represents a term together with its extra disambiguating quantum number(s), labelled by `ν`.
 
 The term symbol (`::T`) can either be a [`Term`](@ref) (for ``LS``-coupling) or a
 `HalfInteger` (for ``jj``-coupling).
 
-The disambiguating quantum number (`::S`) can be anything as long is it is sortable (i.e.
+The disambiguating quantum number(s) (`::S`) can be anything as long is it is sortable (i.e.
 implementing `isless`). It is up to the user to pick a scheme that is suitable for their
-application. See "[Disambiguating quantum numbers](@ref)" in the manual for discussion on how
-it is used in AtomicLevels.
+application. See "[Disambiguating quantum numbers](@ref)" in the manual for discussion on
+how it is used in AtomicLevels.
 
 See also: [`Term`](@ref), [`Seniority`](@ref)
 
@@ -79,12 +79,12 @@ See also: [`Term`](@ref), [`Seniority`](@ref)
 
     IntermediateTerm(term, ν)
 
-Constructs and intermediate term with term symbol `term` and disambiguating quantum number
-`ν`.
+Constructs and intermediate term with term symbol `term` and disambiguating quantum
+number(s) `ν`.
 
 # Properties
 
-To access the term symbol and the disambiguating quantum number, you can use the
+To access the term symbol and the disambiguating quantum number(s), you can use the
 `.term :: T` and `.ν :: S` (or `.nu :: S`) properties, respectively. E.g.:
 
 ```jldoctest

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -3,9 +3,15 @@
 """
     struct Term
 
-Represent a term symbol ``{}^{2S+1}L_{J}`` with specific parity in LS-coupling. As determining
-valid ``J`` values is simple for given ``S`` and ``L`` (``|L - S| \\leq J \\leq L+S``), it
-is not specified.
+Represents a term symbol with specific parity in LS-coupling.
+
+Only the ``L``, ``S`` and parity values of the symbol ``{}^{2S+1}L_{J}`` are specified. To
+specify a _level_, the ``J`` value would have to be specified separately. The valid ``J``
+values corresponding to given ``L`` and ``S`` fall in the following range:
+
+```math
+|L - S| \\leq J \\leq L+S
+```
 
 # Constructors
 
@@ -14,6 +20,22 @@ is not specified.
 Constructs a `Term` object with the given ``L`` and ``S`` quantum numbers and parity. `L`
 and `S` both have to be convertible to `HalfInteger`s and `parity` must be of type
 [`Parity`](@ref) or `±1`.
+
+See also: [`@T_str`](@ref)
+
+# Properties
+
+To access the quantum number values, you can use the `.L`, `.S` and `.parity` properties to
+access the ``L``, ``S`` and parity values (represented with [`Parity`](@ref)), respectively.
+E.g.:
+
+```jldoctest
+julia> t = Term(2, 1//2, p"odd")
+²Dᵒ
+
+julia> t.L, t.S, t.parity
+(2, 1/2, odd)
+```
 """
 struct Term
     L::HalfInt
@@ -28,6 +50,18 @@ end
 Term(L::Real, S::Real, parity::Union{Parity,Integer}) =
     Term(convert(HalfInteger, L), convert(HalfInteger, S), convert(Parity, parity))
 
+"""
+    parse(::Type{Term}, ::AbstractString) -> Term
+
+Parses a string into a [`Term`](@ref) object.
+
+```jldoctest
+julia> parse(Term, "4Po")
+⁴Pᵒ
+```
+
+See also: [`@T_str`](@ref)
+"""
 function Base.parse(::Type{Term}, s::AbstractString)
     m = match(r"([0-9]+)([A-Z]|\[[0-9/]+\])([oe ]{0,1})", s)
     isnothing(m) && throw(ArgumentError("Invalid term string $s"))

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -236,15 +236,20 @@ function terms(config::Configuration{O}) where {O<:AbstractOrbital}
 end
 
 """
-    count_terms(orb, occ, term)
+    count_terms(orbital, occupation, term)
 
-Count how many times `term` occurs among the valid terms of `orb`^`occ`. For example:
+Count how many times `term` occurs among the valid terms of `orbital^occupation`.
 
 ```jldoctest
 julia> count_terms(o"1s", 2, T"1S")
 1
+
+julia> count_terms(ro"6h", 4, 8)
+4
 ```
 """
+function count_terms end
+
 function count_terms(orb::Orbital, occ::Int, term::Term)
     ℓ = orb.ℓ
     g = degeneracy(orb)

--- a/test/intermediate_terms.jl
+++ b/test/intermediate_terms.jl
@@ -1,9 +1,26 @@
+using AtomicLevels
+using HalfIntegers
+using Test
+
 @testset "Intermediate terms" begin
     @testset "LS coupling" begin
         @test !AtomicLevels.istermvalid(T"2S", Seniority(2))
 
         @test string(IntermediateTerm(T"2D", Seniority(3))) == "₃²D"
         @test string(IntermediateTerm(T"2D", 3)) == "₍₃₎²D"
+
+        for t in [T"2D", T"2Do"], ν in [1, Seniority(2), 3]
+            it = IntermediateTerm(t, ν)
+            @test length(propertynames(it)) == 3
+            @test hasproperty(it, :term)
+            @test hasproperty(it, :ν)
+            @test hasproperty(it, :nu)
+            @test it.term == t
+            @test it.ν == it.nu
+            @test it.nu == ν
+            @test !hasproperty(it, :foo)
+            @test_throws ErrorException it.foo
+        end
 
         @testset "Seniority" begin
             # Table taken from p. 25 of


### PR DESCRIPTION
With #64 in mind, but also other edits.

* I added `.nu` as a property to `IntermediateTerm`. I think ideally we'd provide such fallbacks in all the cases where we're using Unicode as fields.

* I am documenting the various fields as the official API to access e.g. the L & S quantum numbers of a term etc.

* Probably not worth it, but one could rename `Term -> LSTerm`, to make it more explicit. Theoretically, one could also have `LSJTerm` (or should it be [`LSJLevel` then](https://en.wikipedia.org/wiki/Term_symbol#Terms,_levels,_and_states)?).