### PR TITLE
Documentation build fixes

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -45,7 +45,8 @@ makedocs(
                 )
             )
         ))
-    )
+    ),
+    strict = true,
 )
 
 deploydocs(repo = "github.com/JuliaAtoms/AtomicLevels.jl.git")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,7 @@
 using Documenter
 using AtomicLevels
 
+DocMeta.setdocmeta!(AtomicLevels, :DocTestSetup, :(using AtomicLevels); recursive=true)
 makedocs(
     modules = [AtomicLevels],
     sitename = "AtomicLevels",

--- a/docs/src/configurations.md
+++ b/docs/src/configurations.md
@@ -209,8 +209,7 @@ julia> excited_configurations(first(scs"1s2"), sos"2[s-p]"...)
  2p₋₁α 2p₀α
  2p₋₁α 2p₀β
  2p₋₁α 2p₁α
- 2p₋₁α 2p₁β
- 2p₋₁β 2p₀α
+ ⋮
  2p₋₁β 2p₀β
  2p₋₁β 2p₁α
  2p₋₁β 2p₁β

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -13,7 +13,7 @@ end
 ```@autodocs
 Modules = [AtomicLevels]
 Public = false
-Filter = fn -> fn !== Base.parse
+Filter = fn -> !in(fn, [Base.parse, Base.fill, Base.fill!])
 ```
 
 ```@meta

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -13,6 +13,7 @@ end
 ```@autodocs
 Modules = [AtomicLevels]
 Public = false
+Filter = fn -> fn !== Base.parse
 ```
 
 ```@meta

--- a/docs/src/terms.md
+++ b/docs/src/terms.md
@@ -151,7 +151,7 @@ individual subshells:
 
 ```jldoctest intermediate_term_examples
 julia> its = intermediate_terms(c"3p2 4s 5p2")
-3-element Array{Array{IntermediateTerm,1},1}:
+3-element Array{Array{IntermediateTerm{Term,Seniority},1},1}:
  [₀¹S, ₂¹D, ₂³P]
  [₁²S]
  [₀¹S, ₂¹D, ₂³P]
@@ -243,7 +243,7 @@ each subshell of `3p² 4s 5p²`
 
 ```jldoctest intermediate_term_examples
 julia> last.(its)
-3-element Array{IntermediateTerm,1}:
+3-element Array{IntermediateTerm{Term,Seniority},1}:
  ₂³P
  ₁²S
  ₂³P

--- a/src/configurations.jl
+++ b/src/configurations.jl
@@ -960,7 +960,7 @@ julia> spin_configurations(c"1s2")
 
 julia> spin_configurations(c"1s2"s)
 1-element Array{Configuration{SpinOrbital{Orbital{Int64},Tuple{Int64,HalfIntegers.Half{Int64}}}},1}:
- 1s²
+ 1s₀α 1s₀β
 
 julia> spin_configurations(c"1s ks")
 4-element Array{Configuration{SpinOrbital{#s16,Tuple{Int64,HalfIntegers.Half{Int64}}} where #s16<:Orbital},1}:

--- a/src/configurations.jl
+++ b/src/configurations.jl
@@ -838,7 +838,7 @@ non-relativistic orbital with `n` and `ℓ` quantum numbers, with given occupanc
 
 ```jldoctest
 julia> AtomicLevels.rconfigurations_from_orbital(3, 1, 2)
-3-element Array{Configuration{RelativisticOrbital{N}} where N,1}:
+3-element Array{Configuration{#s21} where #s21<:RelativisticOrbital,1}:
  3p-²
  3p- 3p
  3p²
@@ -880,7 +880,7 @@ non-relativistic version of the `orbital` with a given occupancy.
 
 ```jldoctest
 julia> AtomicLevels.rconfigurations_from_orbital(o"3p", 2)
-3-element Array{Configuration{RelativisticOrbital{N}} where N,1}:
+3-element Array{Configuration{#s21} where #s21<:RelativisticOrbital,1}:
  3p-²
  3p- 3p
  3p²
@@ -936,7 +936,7 @@ and `occupancy` are integers, and `ℓ` is in spectroscopic notation.
 
 ```jldoctest
 julia> rcs"3p2"
-3-element Array{Configuration{RelativisticOrbital{N}} where N,1}:
+3-element Array{Configuration{#s21} where #s21<:RelativisticOrbital,1}:
  3p-²
  3p- 3p
  3p²

--- a/src/excited_configurations.jl
+++ b/src/excited_configurations.jl
@@ -223,7 +223,7 @@ julia> excited_configurations(first(scs"1s2"), sos"k[s]"...) do dst,src
 
 julia> excited_configurations((a,b) -> a.m == b.m ? a : nothing,
                               spin_configurations(c"1s"), sos"k[s-d]"..., keep_parity=false)
-8-element Array{Configuration{SpinOrbital{#s16,Tuple{Int64,Half{Int64}}} where #s16<:Orbital},1}:
+8-element Array{Configuration{SpinOrbital{#s16,Tuple{Int64,HalfIntegers.Half{Int64}}} where #s16<:Orbital},1}:
  1s₀α
  ks₀α
  kp₀α

--- a/src/intermediate_terms.jl
+++ b/src/intermediate_terms.jl
@@ -139,7 +139,7 @@ orbital `orb` and occupation `w`.
 
 ```jldoctest
 julia> intermediate_terms(o"2p", 2)
-3-element Array{IntermediateTerm,1}:
+3-element Array{IntermediateTerm{Term,Seniority},1}:
  ₀¹S
  ₂¹D
  ₂³P
@@ -150,11 +150,11 @@ which occupancy a certain term is first seen, cf.
 
 ```jldoctest
 julia> intermediate_terms(o"3d", 1)
-1-element Array{IntermediateTerm,1}:
+1-element Array{IntermediateTerm{Term,Seniority},1}:
  ₁²D
 
 julia> intermediate_terms(o"3d", 3)
-8-element Array{IntermediateTerm,1}:
+8-element Array{IntermediateTerm{Term,Seniority},1}:
  ₁²D
  ₃²P
  ₃²D
@@ -197,7 +197,7 @@ Generate the intermediate terms for each subshell of `config`.
 
 ```jldoctest
 julia> intermediate_terms(c"1s 2p3")
-2-element Array{Array{IntermediateTerm,1},1}:
+2-element Array{Array{IntermediateTerm{Term,Seniority},1},1}:
  [₁²S]
  [₁²Pᵒ, ₃²Dᵒ, ₃⁴Sᵒ]
 

--- a/src/intermediate_terms.jl
+++ b/src/intermediate_terms.jl
@@ -202,9 +202,9 @@ julia> intermediate_terms(c"1s 2p3")
  [₁²Pᵒ, ₃²Dᵒ, ₃⁴Sᵒ]
 
 julia> intermediate_terms(rc"3d2 5g3")
-2-element Array{Array{HalfIntegers.Half{Int64},1},1}:
- [0, 2, 4]
- [3/2, 5/2, 7/2, 9/2, 9/2, 11/2, 13/2, 15/2, 17/2, 21/2]
+2-element Array{Array{IntermediateTerm{HalfIntegers.Half{Int64},Seniority},1},1}:
+ [₀0, ₂2, ₂4]
+ [₁9/2, ₃3/2, ₃5/2, ₃7/2, ₃9/2, ₃11/2, ₃13/2, ₃15/2, ₃17/2, ₃21/2]
 ```
 """
 function intermediate_terms(config::Configuration)


### PR DESCRIPTION
Following up on https://github.com/JuliaAtoms/AtomicLevels.jl/pull/53#issuecomment-651616063 -- documentation should build without errors now. Could enable `strict = true` actually.