### PR TITLE
Update Travis links to point to travis-ci.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,3 +51,4 @@ jobs:
                                                Pkg.instantiate()'
         - julia --project=docs/ docs/make.jl
       after_success: skip
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,3 @@ jobs:
                                                Pkg.instantiate()'
         - julia --project=docs/ docs/make.jl
       after_success: skip
-

--- a/README.org
+++ b/README.org
@@ -2,7 +2,7 @@
 #+AUTHOR: Stefanos Carlström
 #+EMAIL: stefanos.carlstrom@gmail.com
 
-[[https://travis-ci.org/JuliaAtoms/AtomicLevels.jl][https://travis-ci.org/JuliaAtoms/AtomicLevels.jl.svg?branch=master]]
+[[https://travis-ci.com/JuliaAtoms/AtomicLevels.jl][https://travis-ci.com/JuliaAtoms/AtomicLevels.jl.svg?branch=master]]
 [[https://ci.appveyor.com/project/juliaatoms/atomiclevels-jl][https://img.shields.io/appveyor/ci/juliaatoms/atomiclevels-jl.svg?logo=appveyor]]
 [[https://codecov.io/gh/JuliaAtoms/AtomicLevels.jl][https://codecov.io/gh/JuliaAtoms/AtomicLevels.jl/branch/master/graph/badge.svg]]
 


### PR DESCRIPTION
Trying out the migration with one repo for now (already migrated in the Travis UI). Ref: https://discourse.julialang.org/t/reminder-travis-ci-org-shuts-down-on-december-31-2020/47234