### PR TITLE
Added string macro for constructing spin-orbitals (closes #58)

### DIFF
--- a/docs/src/orbitals.md
+++ b/docs/src/orbitals.md
@@ -41,7 +41,9 @@ used to construct whole lists of them very easily.
 
 ```@docs
 @o_str
+@so_str
 @ro_str
+@rso_str
 @os_str
 @sos_str
 @ros_str

--- a/src/configurations.jl
+++ b/src/configurations.jl
@@ -388,7 +388,7 @@ julia> c"[Kr] 4d10 5s2 4f2"s
 ```
 """
 macro c_str(conf_str, suffix="")
-    parse_conf_str(Orbital, conf_str, suffix)
+    :(parse_conf_str(Orbital, $conf_str, $suffix))
 end
 
 """
@@ -412,9 +412,7 @@ julia> rc"2p- 1s"s
 ```
 """
 macro rc_str(conf_str, suffix="")
-    parse_conf_str(RelativisticOrbital, conf_str, suffix)
-    suffix ∈ ["", "s"] || throw(ArgumentError("Unknown configuration suffix $suffix"))
-    parse(Configuration{RelativisticOrbital}, conf_str, sorted=suffix=="s")
+    :(parse_conf_str(RelativisticOrbital, $conf_str, $suffix))
 end
 
 """
@@ -446,7 +444,7 @@ julia> scs"1s2 2p2"
 ```
 """
 macro scs_str(conf_str, suffix="")
-    spin_configurations(parse_conf_str(Orbital, conf_str, suffix))
+    :(spin_configurations(parse_conf_str(Orbital, $conf_str, $suffix)))
 end
 
 Base.getindex(conf::Configuration{O}, i::Integer) where O =
@@ -948,7 +946,7 @@ julia> rcs"3p2"
 ```
 """
 macro rcs_str(s)
-    rconfigurations_from_nrstring(s)
+    :(rconfigurations_from_nrstring($s))
 end
 
 

--- a/src/orbitals.jl
+++ b/src/orbitals.jl
@@ -253,7 +253,7 @@ Fd
 ```
 """
 macro o_str(orb_str)
-    orbital_from_string(Orbital, orb_str)
+    :(orbital_from_string(Orbital, $orb_str))
 end
 
 function orbitals_from_string(::Type{O}, orbs_str::AbstractString) where {O<:AbstractOrbital}
@@ -294,7 +294,7 @@ julia> os"5[d] 6[s-p] k[7-10]"
 ```
 """
 macro os_str(orbs_str)
-    orbitals_from_string(Orbital, orbs_str)
+    :(orbitals_from_string(Orbital, $orbs_str))
 end
 
 export AbstractOrbital, Orbital,

--- a/src/relativistic_orbitals.jl
+++ b/src/relativistic_orbitals.jl
@@ -206,7 +206,7 @@ Kf-
 ```
 """
 macro ro_str(orb_str)
-    orbital_from_string(RelativisticOrbital, orb_str)
+    :(orbital_from_string(RelativisticOrbital, $orb_str))
 end
 
 """
@@ -232,7 +232,7 @@ julia> ros"2[s-p] 3[p] k[0-d]"
 ```
 """
 macro ros_str(orbs_str)
-    orbitals_from_string(RelativisticOrbital, orbs_str)
+    :(orbitals_from_string(RelativisticOrbital, $orbs_str))
 end
 
 function kappa_from_string(κ_str)
@@ -255,7 +255,7 @@ julia> κ"s", κ"p-", κ"p"
 ```
 """
 macro κ_str(κ_str)
-    kappa_from_string(κ_str)
+    :(kappa_from_string($κ_str))
 end
 
 """

--- a/src/spin_orbitals.jl
+++ b/src/spin_orbitals.jl
@@ -224,7 +224,7 @@ julia> sos"3[s-p]"
 ```
 """
 macro sos_str(orbs_str)
-    reduce(vcat, map(spin_orbitals, orbitals_from_string(Orbital, orbs_str)))
+    :(reduce(vcat, map(spin_orbitals, orbitals_from_string(Orbital, $orbs_str))))
 end
 
 """
@@ -248,7 +248,7 @@ julia> rsos"3[s-p]"
 ```
 """
 macro rsos_str(orbs_str)
-    reduce(vcat, map(spin_orbitals, orbitals_from_string(RelativisticOrbital, orbs_str)))
+    :(reduce(vcat, map(spin_orbitals, orbitals_from_string(RelativisticOrbital, $orbs_str))))
 end
 
 export SpinOrbital, spin_orbitals, @so_str, @rso_str, @sos_str, @rsos_str

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -101,7 +101,7 @@ julia> T"2[3/2]o" # jK coupling, common in noble gases
 ```
 """
 macro T_str(s::AbstractString)
-    parse(Term, s)
+    :(parse(Term, $s))
 end
 
 Base.zero(::Type{Term}) = T"1S"

--- a/test/orbitals.jl
+++ b/test/orbitals.jl
@@ -278,6 +278,32 @@ using Random
 
         @test "$(soα)" == "1s₀α"
         @test "$(po₊β)" == "2p₁β"
+
+        @testset "Construction" begin
+            @test so"1s(0,α)" == SpinOrbital(o"1s", (0,1/2))
+            @test so"1s(0,β)" == SpinOrbital(o"1s", (0,-1/2))
+            @test so"2p(1,β)" == SpinOrbital(o"2p", (1,-1/2))
+            @test so"1s(0,-1/2)" == SpinOrbital(o"1s", (0,-1/2))
+            @test so"1s(0,-0.5)" == SpinOrbital(o"1s", (0,-1/2))
+            @test so"1s(0,1/2)" == SpinOrbital(o"1s", (0,1/2))
+            @test_throws ArgumentError rso"1s(0,1/2)"
+            @test rso"1s(1/2)" == SpinOrbital(ro"1s", (1/2))
+            @test rso"1s(α)" == SpinOrbital(ro"1s", (1/2)) # This should not work, but hey...
+            @test_throws ArgumentError rso"1s(3/2)"
+            @test rso"2p(3/2)" == SpinOrbital(ro"2p", (3/2))
+            @test rso"3p(-3/2)" == SpinOrbital(ro"3p", (-3/2))
+            @test rso"3p(-1/2)" == SpinOrbital(ro"3p", (-1/2))
+            @test_throws ArgumentError rso"3p(5/2)"
+            @test rso"3p(1/2)" == SpinOrbital(ro"3p", (1/2))
+            @test rso"3p-(1/2)" == SpinOrbital(ro"3p-", (1/2))
+            @test_throws ArgumentError rso"3p-(3/2)"
+            @test_throws ArgumentError rso"3p-(-3/2)"
+            @test rso"3p-(-1/2)" == SpinOrbital(ro"3p-", (-1/2))
+            @test_throws ArgumentError rso"3d-(-5/2)"
+            @test_throws ArgumentError rso"3d-(..)"
+            @test rso"3d-(-3/2)" == SpinOrbital(ro"3d-", (-3/2))
+            @test rso"3d(5/2)" == SpinOrbital(ro"3d", (5/2))
+        end
     end
 
     @testset "Internal methods" begin


### PR DESCRIPTION
We can now do

``` julia
julia> so"2p(1,-1/2)"
2p₁β

julia> rso"3d(2.5)"
3d(5/2)
```

----

#