### PR TITLE
Export kappa-lj conversion functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomicLevels"
 uuid = "10933b4c-d60f-11e8-1fc6-bd9035a249a1"
 authors = ["Stefanos Carlström <stefanos.carlstrom@gmail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -40,7 +40,7 @@ parity
 ## JJ to LSJ
 
 ```@docs
-jj2lsj
+jj2ℓsj
 ```
 
 ## Index

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -43,6 +43,14 @@ parity
 jj2ℓsj
 ```
 
+## Conversion of angular momentum quantum numbers
+
+```@docs
+κ2ℓ
+κ2j
+ℓj2κ
+```
+
 ## Index
 
 ```@index

--- a/src/AtomicLevels.jl
+++ b/src/AtomicLevels.jl
@@ -29,4 +29,7 @@ module Utils
 include("utils/print_states.jl")
 end
 
+# Deprecations
+@deprecate jj2lsj(args...) jj2ℓsj(args...)
+
 end # module

--- a/src/jj2lsj.jl
+++ b/src/jj2lsj.jl
@@ -60,7 +60,7 @@ function rotate!(blocks::Vector{M}, orbs::RelativisticOrbital...) where {T,M<:Ab
     # We sort by mⱼ and remove the first and last elements since they
     # are pure and trivially unity.
     ℓms = sort(vcat([[(ℓ,m,s) for m ∈ -ℓ:ℓ] for s = -half(1):half(1)]...)[2:end-1], by=((ℓms)) -> (ℓms[2],+(ℓms[2:3]...)))
-    jmⱼ = sort(vcat([[(j,mⱼ) for mⱼ ∈ -j:j] for j ∈ [kappa_to_j(o.κ) for o in orbs]]...), by=last)[2:end-1]
+    jmⱼ = sort(vcat([[(j,mⱼ) for mⱼ ∈ -j:j] for j ∈ [κ2j(o.κ) for o in orbs]]...), by=last)[2:end-1]
     for (a,(ℓ,m,s)) in enumerate(ℓms)
         bi = cld(a, 2)
         o = 2*(bi-1)
@@ -106,11 +106,11 @@ function jj2lsj(::Type{T}, orbs::RelativisticOrbital...) where T
         i = findall(isequal((n,ℓ)), nℓs)
         subspace = orbs[i]
         mⱼ = map(subspace) do orb
-            j = convert(Rational, kappa_to_j(orb.κ))
+            j = convert(Rational, κ2j(orb.κ))
             -j:j
         end
 
-        jₘₐₓ = maximum([kappa_to_j(o.κ) for o in subspace])
+        jₘₐₓ = maximum([κ2j(o.κ) for o in subspace])
         pure = [Matrix{T}(undef,1,1),Matrix{T}(undef,1,1)]
         pure[1][1] = convert(T, ClebschGordanℓs(ℓ,-ℓ,half(1),-half(1),jₘₐₓ,-jₘₐₓ))
         pure[2][1] = convert(T, ClebschGordanℓs(ℓ,ℓ,half(1),half(1),jₘₐₓ,jₘₐₓ))

--- a/src/jj2lsj.jl
+++ b/src/jj2lsj.jl
@@ -73,7 +73,7 @@ function rotate!(blocks::Vector{M}, orbs::RelativisticOrbital...) where {T,M<:Ab
 end
 
 """
-    jj2lsj([T=Float64, ]orbs...)
+    jj2ℓsj([T=Float64, ]orbs...)
 
 Generates the block-diagonal matrix that transforms jj-coupled
 configurations to lsj-coupled ones.
@@ -100,7 +100,7 @@ E.g. the p-block will have the following structure:
 ```
 
 """
-function jj2lsj(::Type{T}, orbs::RelativisticOrbital...) where T
+function jj2ℓsj(::Type{T}, orbs::RelativisticOrbital...) where T
     nℓs = map(o -> (o.n, κ2ℓ(o.κ)), sort([orbs...]))
     blocks = map(unique(nℓs)) do (n,ℓ)
         i = findall(isequal((n,ℓ)), nℓs)
@@ -133,7 +133,7 @@ function jj2lsj(::Type{T}, orbs::RelativisticOrbital...) where T
     end
     R
 end
-jj2lsj(orbs::RelativisticOrbital...) = jj2lsj(Float64, orbs...)
+jj2ℓsj(orbs::RelativisticOrbital...) = jj2ℓsj(Float64, orbs...)
 
 angular_integral(a::SpinOrbital{<:Orbital}, b::SpinOrbital{<:Orbital}) =
     a.orb.ℓ == b.orb.ℓ && a.m == b.m
@@ -147,7 +147,7 @@ angular_integral(a::SpinOrbital{<:Orbital}, b::SpinOrbital{<:RelativisticOrbital
 angular_integral(a::SpinOrbital{<:RelativisticOrbital}, b::SpinOrbital{<:Orbital}) =
     conj(angular_integral(b, a))
 
-function jj2lsj(sorb::SpinOrbital{<:Orbital})
+function jj2ℓsj(sorb::SpinOrbital{<:Orbital})
     orb,(mℓ,ms) = sorb.orb,sorb.m
     @unpack n,ℓ = orb
     mj = mℓ + ms
@@ -157,7 +157,7 @@ function jj2lsj(sorb::SpinOrbital{<:Orbital})
     end
 end
 
-function jj2lsj(sorb::SpinOrbital{<:RelativisticOrbital})
+function jj2ℓsj(sorb::SpinOrbital{<:RelativisticOrbital})
     orb,(mj,) = sorb.orb,sorb.m
     @unpack n,ℓ,j = orb
     map(max(-ℓ, mj-half(1)):min(ℓ, mj+half(1))) do mℓ
@@ -167,11 +167,11 @@ function jj2lsj(sorb::SpinOrbital{<:RelativisticOrbital})
     end
 end
 
-function jj2lsj(sorbs::AbstractVector{<:SpinOrbital{<:RelativisticOrbital}})
+function jj2ℓsj(sorbs::AbstractVector{<:SpinOrbital{<:RelativisticOrbital}})
     @assert issorted(sorbs)
     # For each jj spin-orbital, find all corresponding ls
     # spin-orbitals with their CG coeffs.
-    couplings = map(jj2lsj, sorbs)
+    couplings = map(jj2ℓsj, sorbs)
 
     CGT = typeof(couplings[1][1][2])
     LSOT = eltype(reduce(vcat, map(c -> map(first, c), couplings)))
@@ -210,4 +210,4 @@ function jj2lsj(sorbs::AbstractVector{<:SpinOrbital{<:RelativisticOrbital}})
     ls_orbitals, blocks
 end
 
-export jj2lsj, ClebschGordan, ClebschGordanℓs
+export jj2ℓsj, ClebschGordan, ClebschGordanℓs

--- a/src/jj2lsj.jl
+++ b/src/jj2lsj.jl
@@ -56,7 +56,7 @@ We know [Eq. (3.8.58)] that
 function rotate!(blocks::Vector{M}, orbs::RelativisticOrbital...) where {T,M<:AbstractMatrix{T}}
     2length(blocks) == sum(degeneracy.(orbs))-2 ||
         throw(ArgumentError("Invalid block size for $(orbs...)"))
-    ℓ = kappa_to_ℓ(first(orbs).κ)
+    ℓ = κ2ℓ(first(orbs).κ)
     # We sort by mⱼ and remove the first and last elements since they
     # are pure and trivially unity.
     ℓms = sort(vcat([[(ℓ,m,s) for m ∈ -ℓ:ℓ] for s = -half(1):half(1)]...)[2:end-1], by=((ℓms)) -> (ℓms[2],+(ℓms[2:3]...)))
@@ -101,7 +101,7 @@ E.g. the p-block will have the following structure:
 
 """
 function jj2lsj(::Type{T}, orbs::RelativisticOrbital...) where T
-    nℓs = map(o -> (o.n, kappa_to_ℓ(o.κ)), sort([orbs...]))
+    nℓs = map(o -> (o.n, κ2ℓ(o.κ)), sort([orbs...]))
     blocks = map(unique(nℓs)) do (n,ℓ)
         i = findall(isequal((n,ℓ)), nℓs)
         subspace = orbs[i]

--- a/src/jj_terms.jl
+++ b/src/jj_terms.jl
@@ -33,7 +33,7 @@ julia> terms(ro"4f", 4)
 ```
 """
 function terms(orb::RelativisticOrbital, w::Int=one(Int))
-    j = kappa_to_j(orb.κ)
+    j = κ2j(orb.κ)
     0 <= w <= 2*j+1 || throw(DomainError(w, "w must be 0 <= w <= 2j+1 (=$(2j+1)) for j=$j"))
     # We can equivalently calculate the JJ terms for holes, so we'll do that when we have
     # fewer holes than particles on this shell
@@ -89,7 +89,7 @@ function _terms_jw(j::HalfInteger, w::Integer)
 end
 
 function count_terms(orb::RelativisticOrbital, w::Integer, J::HalfInteger)
-    j = kappa_to_j(orb.κ)
+    j = κ2j(orb.κ)
     0 <= w <= 2*j+1 || throw(DomainError(w, "w must be 0 <= w <= 2j+1 (=$(2j+1)) for j=$j"))
     # We can equivalently calculate the JJ terms for holes, so we'll do that when we have
     # fewer holes than particles on this shell

--- a/src/relativistic_orbitals.jl
+++ b/src/relativistic_orbitals.jl
@@ -307,4 +307,4 @@ julia> nonrelorbital(ro"2p-")
 nonrelorbital(o::Orbital) = o
 nonrelorbital(o::RelativisticOrbital) = Orbital(o.n, o.ℓ)
 
-export RelativisticOrbital, @ro_str, @ros_str, @κ_str, nonrelorbital
+export RelativisticOrbital, @ro_str, @ros_str, @κ_str, nonrelorbital, κ2ℓ, κ2j, ℓj2κ

--- a/src/relativistic_orbitals.jl
+++ b/src/relativistic_orbitals.jl
@@ -13,13 +13,13 @@ function κ2ℓ(κ::Integer)
 end
 
 """
-    kappa_to_j(κ::Integer) :: HalfInteger
+    κ2j(κ::Integer) -> HalfInteger
 
 Calculate the `j` quantum number corresponding to the `κ` quantum number.
 
-Note: `κ` is always an integer.
+Note: `κ` is always an integer, but `j` will be a half-integer value.
 """
-function kappa_to_j(kappa::Integer)
+function κ2j(kappa::Integer)
     kappa == zero(kappa) && throw(ArgumentError("κ can not be zero"))
     half(2*abs(kappa) - 1)
 end
@@ -140,7 +140,7 @@ mqtype(::RelativisticOrbital{MQ}) where MQ = MQ
 
 Base.propertynames(::RelativisticOrbital) = (fieldnames(RelativisticOrbital)..., :j, :ℓ)
 function Base.getproperty(o::RelativisticOrbital, s::Symbol)
-    s === :j ? kappa_to_j(o.κ) :
+    s === :j ? κ2j(o.κ) :
     s === :ℓ ? κ2ℓ(o.κ) :
     getfield(o, s)
 end

--- a/src/relativistic_orbitals.jl
+++ b/src/relativistic_orbitals.jl
@@ -25,11 +25,11 @@ function κ2j(kappa::Integer)
 end
 
 """
-    ℓj2κ(ℓ::Integer, j::Real) :: Integer
+    ℓj2κ(ℓ::Integer, j::Real) -> Integer
 
 Converts a valid `(ℓ, j)` pair to the corresponding `κ` value.
 
-**Note:** there is a one-to-one correspondence between valid `(ℓ,j)` pairs and `κ` values
+Note: there is a one-to-one correspondence between valid `(ℓ,j)` pairs and `κ` values
 such that for `j = ℓ ± 1/2`, `κ = ∓(j + 1/2)`.
 """
 function ℓj2κ(ℓ::Integer, j::Real)

--- a/src/relativistic_orbitals.jl
+++ b/src/relativistic_orbitals.jl
@@ -25,14 +25,14 @@ function κ2j(kappa::Integer)
 end
 
 """
-    ℓj_to_kappa(ℓ::Integer, j::Real) :: Integer
+    ℓj2κ(ℓ::Integer, j::Real) :: Integer
 
 Converts a valid `(ℓ, j)` pair to the corresponding `κ` value.
 
 **Note:** there is a one-to-one correspondence between valid `(ℓ,j)` pairs and `κ` values
 such that for `j = ℓ ± 1/2`, `κ = ∓(j + 1/2)`.
 """
-function ℓj_to_kappa(ℓ::Integer, j::Real)
+function ℓj2κ(ℓ::Integer, j::Real)
     assert_orbital_ℓj(ℓ, j)
     (j < ℓ) ? ℓ : -(ℓ + 1)
 end
@@ -124,7 +124,7 @@ struct RelativisticOrbital{N<:MQ} <: AbstractOrbital
         new{Symbol}(n, κ)
     end
 end
-RelativisticOrbital(n::MQ, ℓ::Integer, j::Real) = RelativisticOrbital(n, ℓj_to_kappa(ℓ, j))
+RelativisticOrbital(n::MQ, ℓ::Integer, j::Real) = RelativisticOrbital(n, ℓj2κ(ℓ, j))
 
 Base.:(==)(a::RelativisticOrbital, b::RelativisticOrbital) =
     a.n == b.n && a.κ == b.κ
@@ -271,7 +271,7 @@ function kappa_from_string(κ_str)
     m === nothing && throw(ArgumentError("Invalid κ string: $(κ_str)"))
     ℓ = parse_orbital_ℓ(m, 1)
     j = ℓ + half(m[2] == "-" ? -1 : 1)
-    ℓj_to_kappa(ℓ, j)
+    ℓj2κ(ℓ, j)
 end
 
 """

--- a/src/relativistic_orbitals.jl
+++ b/src/relativistic_orbitals.jl
@@ -1,15 +1,15 @@
 # * Relativistic orbital
 
 """
-    kappa_to_ℓ(κ::Integer) :: Integer
+    κ2ℓ(κ::Integer) -> Integer
 
 Calculate the `ℓ` quantum number corresponding to the `κ` quantum number.
 
 Note: `κ` and `ℓ` values are always integers.
 """
-function kappa_to_ℓ(kappa::Integer)
-    kappa == zero(kappa) && throw(ArgumentError("κ can not be zero"))
-    (kappa < 0) ? -(kappa+1) : kappa
+function κ2ℓ(κ::Integer)
+    κ == zero(κ) && throw(ArgumentError("κ can not be zero"))
+    (κ < 0) ? -(κ + 1) : κ
 end
 
 """
@@ -115,7 +115,7 @@ struct RelativisticOrbital{N<:MQ} <: AbstractOrbital
     function RelativisticOrbital(n::Integer, κ::Integer)
         n ≥ 1 || throw(ArgumentError("Invalid principal quantum number $(n)"))
         κ == zero(κ) && throw(ArgumentError("κ can not be zero"))
-        ℓ = kappa_to_ℓ(κ)
+        ℓ = κ2ℓ(κ)
         0 ≤ ℓ && ℓ < n || throw(ArgumentError("Angular quantum number has to be ∈ [0,$(n-1)] when n = $(n)"))
         new{Int}(n, κ)
     end
@@ -141,12 +141,12 @@ mqtype(::RelativisticOrbital{MQ}) where MQ = MQ
 Base.propertynames(::RelativisticOrbital) = (fieldnames(RelativisticOrbital)..., :j, :ℓ)
 function Base.getproperty(o::RelativisticOrbital, s::Symbol)
     s === :j ? kappa_to_j(o.κ) :
-    s === :ℓ ? kappa_to_ℓ(o.κ) :
+    s === :ℓ ? κ2ℓ(o.κ) :
     getfield(o, s)
 end
 
 function Base.show(io::IO, orb::RelativisticOrbital)
-    write(io, "$(orb.n)$(spectroscopic_label(kappa_to_ℓ(orb.κ)))")
+    write(io, "$(orb.n)$(spectroscopic_label(κ2ℓ(orb.κ)))")
     orb.κ > 0 && write(io, "-")
 end
 
@@ -159,13 +159,13 @@ degeneracy(orb::RelativisticOrbital{N}) where N = 2*abs(orb.κ) # 2j + 1 = 2|κ|
 
 function Base.isless(a::RelativisticOrbital, b::RelativisticOrbital)
     nisless(a.n, b.n) && return true
-    aℓ, bℓ = kappa_to_ℓ(a.κ), kappa_to_ℓ(b.κ)
+    aℓ, bℓ = κ2ℓ(a.κ), κ2ℓ(b.κ)
     a.n == b.n && aℓ < bℓ && return true
     a.n == b.n && aℓ == bℓ && abs(a.κ) < abs(b.κ) && return true
     false
 end
 
-parity(orb::RelativisticOrbital) = p"odd"^kappa_to_ℓ(orb.κ)
+parity(orb::RelativisticOrbital) = p"odd"^κ2ℓ(orb.κ)
 symmetry(orb::RelativisticOrbital) = orb.κ
 
 isbound(::RelativisticOrbital{Int}) = true

--- a/test/grasp/rcsfparser.jl
+++ b/test/grasp/rcsfparser.jl
@@ -1,7 +1,7 @@
 using AtomicLevels: CSF
 using HalfIntegers
 
-angularmomentum(o::RelativisticOrbital) = AtomicLevels.kappa_to_j(o.κ)
+angularmomentum(o::RelativisticOrbital) = AtomicLevels.κ2j(o.κ)
 angularmomentum(csf::CSF{O,<:HalfInteger}) where O = last(csf.terms)
 
 # Relativistic CSLs and parsing of GRASP CSL files

--- a/test/jj2lsj.jl
+++ b/test/jj2lsj.jl
@@ -1,9 +1,9 @@
 using LinearAlgebra
 import AtomicLevels: angular_integral
 
-@testset "jj2lsj" begin
+@testset "jj2ℓsj" begin
     @testset "Transform matrix" begin
-        R = jj2lsj(ros"1[s] 2[s-p] k[s-d]"...)
+        R = jj2ℓsj(ros"1[s] 2[s-p] k[s-d]"...)
         # Since it is a rotation matrix, its inverse is simply the
         # transpose.
         @test norm(inv(Matrix(R)) - R') < 10eps()
@@ -16,7 +16,7 @@ import AtomicLevels: angular_integral
                 mℓ,ms = so.m
                 mj = mℓ + ms
                 pure = abs(mj) == ℓ + half(1)
-                linear_combination = jj2lsj(so)
+                linear_combination = jj2ℓsj(so)
                 @test length(linear_combination) == (pure ? 1 : 2)
                 @test norm(last.(linear_combination)) ≈ 1
                 @test all(isequal(mj), map(o -> first(o.m), first.(linear_combination)))
@@ -38,7 +38,7 @@ import AtomicLevels: angular_integral
     end
 
     @testset "#orbitals = $(length(ros))" for (ros,nb) in ((rsos"l[p]", 4), (rsos"k[s-d] l[d]", 18), (filter(o -> o.m[1]==1//2, rsos"l[d]"), 1))
-        os, bs = jj2lsj(ros)
+        os, bs = jj2ℓsj(ros)
         @test length(os) == length(ros)
         for (ro,o) in zip(ros, os)
             @test sum(o.m) == ro.m[1]

--- a/test/orbitals.jl
+++ b/test/orbitals.jl
@@ -22,14 +22,14 @@ using Random
         @test κ2ℓ(-3) == 2
         @test κ2ℓ( 3) == 3
 
-        import AtomicLevels: kappa_to_j
-        @test_throws ArgumentError kappa_to_j(0)
-        @test kappa_to_j(-1) === half(1)
-        @test kappa_to_j( 1) === half(1)
-        @test kappa_to_j(-2) === half(3)
-        @test kappa_to_j( 2) === half(3)
-        @test kappa_to_j(-3) === half(5)
-        @test kappa_to_j( 3) === half(5)
+        import AtomicLevels: κ2j
+        @test_throws ArgumentError κ2j(0)
+        @test κ2j(-1) === half(1)
+        @test κ2j( 1) === half(1)
+        @test κ2j(-2) === half(3)
+        @test κ2j( 2) === half(3)
+        @test κ2j(-3) === half(5)
+        @test κ2j( 3) === half(5)
 
         import AtomicLevels: ℓj_to_kappa
         @test ℓj_to_kappa(0, half(1)) == -1

--- a/test/orbitals.jl
+++ b/test/orbitals.jl
@@ -31,24 +31,24 @@ using Random
         @test κ2j(-3) === half(5)
         @test κ2j( 3) === half(5)
 
-        import AtomicLevels: ℓj_to_kappa
-        @test ℓj_to_kappa(0, half(1)) == -1
+        import AtomicLevels: ℓj2κ
+        @test ℓj2κ(0, half(1)) == -1
         @test κ"s" == -1
-        @test ℓj_to_kappa(1, half(1)) == 1
+        @test ℓj2κ(1, half(1)) == 1
         @test κ"p-" == 1
-        @test ℓj_to_kappa(1, 3//2) == -2
+        @test ℓj2κ(1, 3//2) == -2
         @test κ"p" == -2
-        @test ℓj_to_kappa(2, 3//2) == 2
+        @test ℓj2κ(2, 3//2) == 2
         @test κ"d-" == 2
-        @test ℓj_to_kappa(2, 5//2) == -3
+        @test ℓj2κ(2, 5//2) == -3
         @test κ"d" == -3
-        @test ℓj_to_kappa(3, 5//2) == 3
+        @test ℓj2κ(3, 5//2) == 3
         @test κ"f-" == 3
-        @test ℓj_to_kappa(3, 7//2) == -4
+        @test ℓj2κ(3, 7//2) == -4
         @test κ"f" == -4
-        @test_throws ArgumentError ℓj_to_kappa(0, half(3))
-        @test_throws ArgumentError ℓj_to_kappa(0, 0)
-        @test_throws ArgumentError ℓj_to_kappa(6, 1//2)
+        @test_throws ArgumentError ℓj2κ(0, half(3))
+        @test_throws ArgumentError ℓj2κ(0, 0)
+        @test_throws ArgumentError ℓj2κ(6, 1//2)
     end
 
     @testset "Construction" begin

--- a/test/orbitals.jl
+++ b/test/orbitals.jl
@@ -13,14 +13,14 @@ using Random
         @test_throws ArgumentError assert_orbital_ℓj(5, 1//2)
         @test_throws MethodError assert_orbital_ℓj(HalfInteger(1), HalfInteger(1//2))
 
-        import AtomicLevels: kappa_to_ℓ
-        @test_throws ArgumentError kappa_to_ℓ(0)
-        @test kappa_to_ℓ(-1) == 0
-        @test kappa_to_ℓ( 1) == 1
-        @test kappa_to_ℓ(-2) == 1
-        @test kappa_to_ℓ( 2) == 2
-        @test kappa_to_ℓ(-3) == 2
-        @test kappa_to_ℓ( 3) == 3
+        import AtomicLevels: κ2ℓ
+        @test_throws ArgumentError κ2ℓ(0)
+        @test κ2ℓ(-1) == 0
+        @test κ2ℓ( 1) == 1
+        @test κ2ℓ(-2) == 1
+        @test κ2ℓ( 2) == 2
+        @test κ2ℓ(-3) == 2
+        @test κ2ℓ( 3) == 3
 
         import AtomicLevels: kappa_to_j
         @test_throws ArgumentError kappa_to_j(0)


### PR DESCRIPTION
Also makes the naming of `jj2lsj` function consistent in terms of unicode. Fix #94.