### PR TITLE
Export a function for string to kappa conversion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomicLevels"
 uuid = "10933b4c-d60f-11e8-1fc6-bd9035a249a1"
 authors = ["Stefanos Carlström <stefanos.carlstrom@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"

--- a/docs/src/orbitals.md
+++ b/docs/src/orbitals.md
@@ -61,7 +61,6 @@ isbound
 angular_momenta
 angular_momentum_ranges
 spin_orbitals
-@κ_str
 nonrelorbital
 ```
 

--- a/docs/src/utilities.md
+++ b/docs/src/utilities.md
@@ -43,9 +43,11 @@ parity
 jj2ℓsj
 ```
 
-## Conversion of angular momentum quantum numbers
+## Angular momentum quantum numbers
 
 ```@docs
+str2κ
+@κ_str
 κ2ℓ
 κ2j
 ℓj2κ

--- a/src/relativistic_orbitals.jl
+++ b/src/relativistic_orbitals.jl
@@ -274,7 +274,7 @@ A function to convert the canonical string representation of a ``\\ell_j`` angul
 
 ```jldoctest
 julia> str2κ.(["s", "p-", "p"])
-3-element Vector{Int64}:
+3-element Array{Int64,1}:
  -1
   1
  -2

--- a/src/relativistic_orbitals.jl
+++ b/src/relativistic_orbitals.jl
@@ -266,7 +266,21 @@ macro ros_str(orbs_str)
     orbitals_from_string(RelativisticOrbital, orbs_str)
 end
 
-function kappa_from_string(κ_str)
+"""
+    str2κ(s) -> Int
+
+A function to convert the canonical string representation of a ``\\ell_j`` angular label
+(i.e. `ℓ-` or `ℓ`) into the corresponding ``\\kappa`` quantum number.
+
+```jldoctest
+julia> str2κ.(["s", "p-", "p"])
+3-element Vector{Int64}:
+ -1
+  1
+ -2
+```
+"""
+function str2κ(κ_str)
     m = match(r"^([a-z]|\[[0-9]+\])([-]{0,1})$", κ_str)
     m === nothing && throw(ArgumentError("Invalid κ string: $(κ_str)"))
     ℓ = parse_orbital_ℓ(m, 1)
@@ -286,7 +300,7 @@ julia> κ"s", κ"p-", κ"p"
 ```
 """
 macro κ_str(κ_str)
-    kappa_from_string(κ_str)
+    str2κ(κ_str)
 end
 
 """
@@ -307,4 +321,4 @@ julia> nonrelorbital(ro"2p-")
 nonrelorbital(o::Orbital) = o
 nonrelorbital(o::RelativisticOrbital) = Orbital(o.n, o.ℓ)
 
-export RelativisticOrbital, @ro_str, @ros_str, @κ_str, nonrelorbital, κ2ℓ, κ2j, ℓj2κ
+export RelativisticOrbital, @ro_str, @ros_str, @κ_str, nonrelorbital, str2κ, κ2ℓ, κ2j, ℓj2κ

--- a/test/orbitals.jl
+++ b/test/orbitals.jl
@@ -33,18 +33,25 @@ using Random
 
         import AtomicLevels: ℓj2κ
         @test ℓj2κ(0, half(1)) == -1
+        @test str2κ("s") == -1
         @test κ"s" == -1
         @test ℓj2κ(1, half(1)) == 1
+        @test str2κ("p-") == 1
         @test κ"p-" == 1
         @test ℓj2κ(1, 3//2) == -2
+        @test str2κ("p") == -2
         @test κ"p" == -2
         @test ℓj2κ(2, 3//2) == 2
+        @test str2κ("d-") == 2
         @test κ"d-" == 2
         @test ℓj2κ(2, 5//2) == -3
+        @test str2κ("d") == -3
         @test κ"d" == -3
         @test ℓj2κ(3, 5//2) == 3
+        @test str2κ("f-") == 3
         @test κ"f-" == 3
         @test ℓj2κ(3, 7//2) == -4
+        @test str2κ("f") == -4
         @test κ"f" == -4
         @test_throws ArgumentError ℓj2κ(0, half(3))
         @test_throws ArgumentError ℓj2κ(0, 0)


### PR DESCRIPTION
So that we'd export a function for performing this conversion when the string is not a constant literal. I wasn't quite sure what to call it, but went with something that would be consistent with the conversion functions from #95.

Also, moves the docstring of `@κ_str` to the "Utilities" page, since that seems more approriate.