### PR TITLE
Make ::AbstractOrbital behave like scalars under broadcasting

### DIFF
--- a/src/orbitals.jl
+++ b/src/orbitals.jl
@@ -2,8 +2,13 @@
     abstract type AbstractOrbital
 
 Abstract supertype of all orbital types.
+
+!!! note "Broadcasting"
+
+    When broadcasting, orbital objects behave like scalars.
 """
 abstract type AbstractOrbital end
+Base.Broadcast.broadcastable(x::AbstractOrbital) = Ref(x)
 
 """
     const MQ = Union{Int,Symbol}

--- a/test/orbitals.jl
+++ b/test/orbitals.jl
@@ -417,4 +417,11 @@ using Random
             @test ne == e
         end
     end
+
+    @testset "Broadcasting" begin
+        @test ([o"1s", o"2p"] .== o"1s") == [true, false]
+        @test ([ro"1s", ro"2p-"] .== ro"1s") == [true, false]
+        @test ([so"1s(0,α)", so"2p(0,α)"] .== so"1s(0,α)") == [true, false]
+        @test ([rso"1s(1/2)", rso"2p-(1/2)"] .== rso"1s(1/2)") == [true, false]
+    end
 end


### PR DESCRIPTION
This should not be breaking in any way because so far it is impossible to use orbitals in broadcasting (`length` not defined). So I think this can also go into 0.1.3.