### PR TITLE
Fix a stackoverflow in CSF constructors

### DIFF
--- a/src/csfs.jl
+++ b/src/csfs.jl
@@ -37,7 +37,7 @@ struct CSF{O<:AbstractOrbital, T<:Union{Term,HalfInteger}, S}
     function CSF(config::Configuration{O},
                  subshell_terms::Vector{IntermediateTerm{T,S}},
                  terms::Vector{T}) where {O<:Union{<:Orbital,<:RelativisticOrbital},
-                                          T<:Union{Term,HalfInt}, S}
+                                          T<:Union{Term,HalfInteger}, S}
         length(subshell_terms) == length(peel(config)) ||
             throw(ArgumentError("Need to provide $(length(peel(config))) subshell terms for $(config)"))
         length(terms) == length(peel(config)) ||
@@ -53,7 +53,7 @@ struct CSF{O<:AbstractOrbital, T<:Union{Term,HalfInteger}, S}
     end
 
     CSF(config, subshell_terms::Vector{<:IntermediateTerm}, terms::Vector{<:Real}) =
-        CSF(config, subshell_terms, convert.(HalfInt, terms))
+        CSF(config, subshell_terms, convert.(HalfInteger, terms))
 end
 
 """

--- a/test/csfs.jl
+++ b/test/csfs.jl
@@ -32,6 +32,13 @@ using .ATSPParser
         @test num_electrons(csf) == 4
 
         @test CSF(c"1s2 2p", [IntermediateTerm(T"1S",Seniority(0)), IntermediateTerm(T"2Po", Seniority(1))], [T"1S", T"2Po"]) isa NonRelativisticCSF
+
+        # Test for a potential stackoverflow in CSF constructors
+        @test CSF(
+            rc"1s 2s 2p2",
+            [IntermediateTerm(HalfUInt(j), Seniority(0)) for j in [1//2, 1//2, 0]],
+            HalfUInt[1//2, 0, 0]
+        ) isa CSF
     end
 
     @testset "CSF list generation" begin


### PR DESCRIPTION
The type restrictions are unnecessarily tight in the method signatures for `CSF`. In the MWE, the `convert` nicely gets rid of the `HalfUInt`s in `terms`, but the method still dispatches to same constructors because of the `HalfUInt`s in `subshell_terms`.