### PR TITLE
Implemented orbitals accessor function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomicLevels"
 uuid = "10933b4c-d60f-11e8-1fc6-bd9035a249a1"
 authors = ["Stefanos Carlström <stefanos.carlstrom@gmail.com>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"

--- a/docs/src/configurations.md
+++ b/docs/src/configurations.md
@@ -67,6 +67,7 @@ issimilar
 Base.:(==)(a::Configuration{<:O}, b::Configuration{<:O}) where {O<:AbstractOrbital}
 num_electrons(::Configuration)
 num_electrons(::Configuration, ::AtomicLevels.AbstractOrbital)
+orbitals(::Configuration)
 Base.delete!
 Base.:(+)
 Base.:(-)

--- a/docs/src/csfs.md
+++ b/docs/src/csfs.md
@@ -99,6 +99,7 @@ CSF
 NonRelativisticCSF
 RelativisticCSF
 csfs
+orbitals(::CSF)
 ```
 
 ## Index

--- a/src/configurations.jl
+++ b/src/configurations.jl
@@ -628,6 +628,25 @@ Base.in(orb::O, conf::Configuration{O}) where {O<:AbstractOrbital} =
     orb ∈ conf.orbitals
 
 """
+    orbitals(c::Configuration{O}) -> Vector{O}
+
+Access the underlying list of orbitals
+
+```jldoctest
+julia> orbitals(c"1s2 2s2")
+2-element Vector{Orbital{Int64}}:
+ 1s
+ 2s
+
+julia> orbitals(rc"1s2 2p-2")
+2-element Vector{RelativisticOrbital{Int64}}:
+ 1s
+ 2p-
+```
+"""
+orbitals(conf::Configuration) = conf.orbitals
+
+"""
     filter(f, c::Configuration) -> Configuration
 
 Filter out the orbitals from configuration `c` for which the predicate `f` returns `false`.
@@ -1303,6 +1322,6 @@ Calculates the number of Slater determinants corresponding to the configuration.
 multiplicity(c::Configuration) = prod(binomial.(degeneracy.(c.orbitals), c.occupancy))
 
 export Configuration, @c_str, @rc_str, @sc_str, @rsc_str, @scs_str, @rscs_str, issimilar,
-    num_electrons, core, peel, active, inactive, bound, continuum, parity, ⊗, @rcs_str,
+    num_electrons, orbitals, core, peel, active, inactive, bound, continuum, parity, ⊗, @rcs_str,
     SpinConfiguration, spin_configurations, substitutions, close!,
     nonrelconfiguration, relconfigurations

--- a/src/csfs.jl
+++ b/src/csfs.jl
@@ -75,6 +75,25 @@ Base.isless(a::CSF, b::CSF) = last(a.terms) < last(b.terms)
 num_electrons(csf::CSF) = num_electrons(csf.config)
 
 """
+    orbitals(csf::CSF{O}) -> Vector
+
+Access the underlying list of orbitals
+
+```jldoctest
+julia> csf = first(csfs(rc"1s2 2p-2"))
+1s²   2p-²
+     0     0
+      0     0+
+
+julia> orbitals(csf)
+2-element Vector{RelativisticOrbital{Int64}}:
+ 1s
+ 2p-
+```
+"""
+orbitals(csf::CSF) = orbitals(csf.config)
+
+"""
     csfs(::Configuration) -> Vector{CSF}
     csfs(::Vector{Configuration}) -> Vector{CSF}
 

--- a/test/configurations.jl
+++ b/test/configurations.jl
@@ -3,9 +3,9 @@
         config = Configuration([o"1s", o"2s", o"2p", o"3s", o"3p"], [2,2,6,2,6], [:closed])
         rconfig = Configuration([ro"1s", ro"2s", ro"2p", ro"3s", ro"3p"], [2,2,6,2,6], [:closed], sorted=true)
 
-        @test config.orbitals ==
+        @test orbitals(config) ==
             [o"1s", o"2s", o"2p", o"3s", o"3p"]
-        @test rconfig.orbitals ==
+        @test orbitals(rconfig) ==
             [ro"1s", ro"2s", ro"2p-", ro"2p", ro"3s", ro"3p-", ro"3p"]
 
         @test config.occupancy == [2, 2, 6, 2, 6]

--- a/test/csfs.jl
+++ b/test/csfs.jl
@@ -30,6 +30,7 @@ using .ATSPParser
         @test csf == csf
         @test csf != CSF(rc"1s2 2p- 2p", [IntermediateTerm(0,Seniority(0)), IntermediateTerm(1//2,Seniority(1)), IntermediateTerm(3//2,Seniority(1))], [0, 1//2, 1])
         @test num_electrons(csf) == 4
+        @test orbitals(csf) == [ro"1s", ro"2p-", ro"2p"]
 
         @test CSF(c"1s2 2p", [IntermediateTerm(T"1S",Seniority(0)), IntermediateTerm(T"2Po", Seniority(1))], [T"1S", T"2Po"]) isa NonRelativisticCSF
     end


### PR DESCRIPTION
This is potentially semi-breaking for user code that (like mine)
usually start a calculation by creating a list of `orbitals`, which
will from now on shadow this function. I think it's worth the hassle
though, since this enables us to treat `Configuration`s, `CSF`s, and
`EnergyExpressions.SlaterDeterminant` (and any future many-body object
built from single-particle functions) on an equal footing.