### PR TITLE
Fix printing of spin configurations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AtomicLevels"
 uuid = "10933b4c-d60f-11e8-1fc6-bd9035a249a1"
 authors = ["Stefanos Carlström <stefanos.carlstrom@gmail.com>"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"

--- a/src/configurations.jl
+++ b/src/configurations.jl
@@ -1182,7 +1182,7 @@ macro rsc_str(conf_str, suffix="")
     parse(SpinConfiguration{SpinOrbital{RelativisticOrbital}}, conf_str, sorted=suffix=="s")
 end
 
-function Base.show(io::IO, c::SpinConfiguration)
+function Base.show(io::IO, c::SpinConfiguration{O}) where {O<:SpinOrbital}
     ascii = get(io, :ascii, false)
     nc = length(c)
     if nc == 0
@@ -1190,28 +1190,28 @@ function Base.show(io::IO, c::SpinConfiguration)
         return
     end
 
-    orbitals = Dict{Orbital, Vector{<:SpinOrbital}}()
-    core_orbitals = sort(unique(map(o -> o.orb, core(c).orbitals)))
-    core_cfg = Configuration(core_orbitals, ones(Int, length(core_orbitals))) |> fill |> close
+    core_orbitals = sort(unique(map(o -> o.orb, orbitals(core(c)))))
 
-    if !isempty(core_cfg)
+    if !isempty(core_orbitals)
+        core_cfg = Configuration(core_orbitals, ones(Int, length(core_orbitals))) |> fill |> close
         show(io, core_cfg)
         write(io, " ")
     end
     # if !c.sorted
     # In the unsorted case, we do not yet contract subshells for
     # printing; to be implemented.
-    so = string.(peel(c).orbitals)
+    so = string.(orbitals(peel(c)))
     write(io, join(so, " "))
     return
     # end
-    # for orb in peel(c).orbitals
-    #     orbitals[orb.orb] = push!(get(orbitals, orb.orb, SpinOrbital[]), orb)
+    # os = Dict{Orbital, Vector{O}}()
+    # for orb in orbitals(peel(c))
+    #     os[orb.orb] = push!(get(os, orb.orb, SpinOrbital[]), orb)
     # end
-    # map(sort(collect(keys(orbitals)))) do orb
+    # map(sort(collect(keys(os)))) do orb
     #     ℓ = orb.ℓ
     #     g = degeneracy(orb)
-    #     sub_shell = orbitals[orb]
+    #     sub_shell = os[orb]
     #     if length(sub_shell) == g
     #         format("{1:s}{2:s}", orb, to_superscript(g))
     #     else

--- a/test/configurations.jl
+++ b/test/configurations.jl
@@ -232,6 +232,20 @@
              c"" => "∅"]) do (c,s)
                  @test "$(c)" == s
              end
+
+        # Test pretty-printing of vectors of spin-configurations; if
+        # there is a mix of integer and symbolic principal quantum
+        # numbers, the underlying orbital type of the SpinOrbital
+        # becomes a UnionAll, which complicates printing of the core
+        # configuration (if any).
+        @test string.([sc"1s₀α"]) == ["1s₀α"]
+        @test string.([sc"1s₀α 1s₀β"]) == ["1s₀α 1s₀β"]
+        @test string.([sc"1s₀α ks₀β"]) == ["1s₀α ks₀β"]
+        @test string.([sc"[He]c 2s₀α 2s₀β", sc"[He]c ks₀α ks₀β"]) == ["[He]ᶜ 2s₀α 2s₀β", "[He]ᶜ ks₀α ks₀β"]
+        @test string.([rsc"[He]c 2s(1/2) 2s(-1/2)", sc"[He]c ks₀α ks₀β"]) == ["[He]ᶜ 2s(1/2) 2s(-1/2)", "[He]ᶜ ks₀α ks₀β"]
+        @test string.([rsc"[He]c 2s(1/2) 2s(-1/2)", rsc"[He]c ks(1/2) ks(-1/2)"]) == ["[He]ᶜ 2s(1/2) 2s(-1/2)", "[He]ᶜ ks(1/2) ks(-1/2)"]
+        @test string.([sc"2s₀α 2s₀β", sc"ks₀α ks₀β"]) == ["2s₀α 2s₀β", "ks₀α ks₀β"]
+        @test string.([rsc"2s(1/2) 2s(-1/2)", rsc"ks(1/2) ks(-1/2)"]) == ["2s(1/2) 2s(-1/2)", "ks(1/2) ks(-1/2)"]
     end
 
     @testset "Orbital substitutions" begin


### PR DESCRIPTION
Prior to this PR, the following would fail:
```julia
julia> string.([sc"2s₀α 2s₀β", sc"ks₀α ks₀β"]) == ["2s₀α 2s₀β", "ks₀α ks₀β"]
  MethodError: no method matching Configuration(::Vector{Any}, ::Vector{Int64})
  Closest candidates are:
    Configuration(::Vector{O}, ::Vector{Int64}) where O<:AbstractOrbital at ~/.julia/packages/AtomicLevels/iYHUN/src/configurations.jl:37
    Configuration(::Vector{O}, ::Vector{Int64}, ::Vector{Symbol}; sorted) where O<:AbstractOrbital at ~/.julia/packages/AtomicLevels/iYHUN/src/configurations.jl:37
```